### PR TITLE
Only pick missions for current job, make abandoning a bit more fail-proof

### DIFF
--- a/ICE/Ui/MainWindow.cs
+++ b/ICE/Ui/MainWindow.cs
@@ -130,7 +130,7 @@ namespace ICE.Ui
                 ImGui.Text($"Rank {selectedRankName} Missions");
                 foreach (var entry in MissionInfoDict)
                 {
-                    if (entry.Value.JobId != selectedJobId)
+                    if (entry.Value.JobId != selectedJobId - 1)
                         continue;
 
                     if (selectedRankIndex == 3)

--- a/ICE/Utilities/Utils.cs
+++ b/ICE/Utilities/Utils.cs
@@ -266,8 +266,8 @@ public static unsafe class Utils
                 MissionInfoDict[keyId] = new MissionListInfo()
                 {
                     Name = LeveName,
-                    JobId = JobId,
-                    JobId2 = Job2,
+                    JobId = JobId - 1,
+                    JobId2 = Job2 - 1,
                     Rank = rank,
                     RecipeId = RecipeId,
                     SilverRequirement = silver,


### PR DESCRIPTION
- Check if weather dependent missions match your current job regardless of them being selected on another job
- If no missions are selected on your current job, don't start abandoning all missions
- Make the rank check a bit more tolerant so that any A-1/A-2/A-3 is abandoned if any A-1/A-2/A-3 is selected (instead of abandoning only A-3 missions if only A-3 is selected)
