### PR TITLE
Fix issue with weather forecast

### DIFF
--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -27,7 +27,10 @@ namespace ICE.Ui
 
             (string currentWeather, string nextWeather, string nextWeatherTime) = WeatherForecastHandler.GetNextWeather();
 
-            ImGui.Text($"Weather: {currentWeather} -> {nextWeather} in [{nextWeatherTime}]");
+            if (currentWeather != null)
+            {
+                ImGui.Text($"Weather: {currentWeather} -> {nextWeather} in [{nextWeatherTime}]");
+            }
 
             (var currentTimedBonus, var nextTimedBonus) = PlayerHandlers.GetTimedJob();
             if (currentTimedBonus.Value == null)

--- a/ICE/Utilities/Utils.cs
+++ b/ICE/Utilities/Utils.cs
@@ -75,6 +75,8 @@ public static unsafe class Utils
         return playerState->ClassJobLevels[Svc.Data.GetExcelSheet<ClassJob>().GetRowOrDefault((uint)(job ?? (Player.Available ? Player.Object.GetJob() : 0)))?.ExpArrayIndex ?? 0];
     }
 
+    public static bool IsInCosmicZone() => IsInZone(1237);
+    public static bool IsInSinusArdorum() => IsInZone(1237);
     public static bool IsInZone(uint zoneID) => Svc.ClientState.TerritoryType == zoneID;
     public static uint CurrentTerritory() => GameMain.Instance()->CurrentTerritoryTypeId;
 


### PR DESCRIPTION
These Checks make sure territory is in CosmicExplorationZone
Allow Forecast to Refresh if it's in other Cosmic Exploration Zone (Other than Sinus)
Allow Forecast to Refresh if Current Weather is not in the Forecast (Refresh During Red Alert)