### PR TITLE
Reroll Refinement

### DIFF
--- a/ICE/Scheduler/Tasks/TaskMissionFind.cs
+++ b/ICE/Scheduler/Tasks/TaskMissionFind.cs
@@ -400,7 +400,14 @@ namespace ICE.Scheduler.Tasks
 
                     var rankToReset = missionRanks.Max();
 
-                    foreach (var m in x.StellerMissions)
+                    Random rng = new Random();
+
+                    var missions = x.StellerMissions
+                        .GroupBy(m => CosmicHelper.MissionInfoDict[m.MissionId].Rank) // Group By Rank
+                        .SelectMany(g => g.OrderBy(m => rng.Next())) // Reorder inside each group randomly
+                        .ToArray();
+
+                    foreach (var m in missions)
                     {
                         var missionEntry = CosmicHelper.MissionInfoDict.FirstOrDefault(e => e.Key == m.MissionId);
 


### PR DESCRIPTION
- Add Random Mission to Reset This should prevent resetting only 1st one, and get into static list after a long reroll