### PR TITLE
Expand mission data with attribute flags

### DIFF
--- a/ICE/Config.cs
+++ b/ICE/Config.cs
@@ -63,16 +63,16 @@ namespace ICE
         public bool ShowCreditsColumn { get; set; } = true;
 
         // Gathering Settings
-        public bool SelfRepairGather {  get; set; } = true;
+        public bool SelfRepairGather { get; set; } = true;
         public int RepairPercent { get; set; } = 50;
         public int SelectedGatherIndex { get; set; } = 0;
         public List<GatherBuffProfile> GatherSettings { get; set; } = new()
         {
             new GatherBuffProfile { Id = 0, Name = "Default"},
         };
-        
+
         // Gamba settings
-        public List<Gamba>GambaItemWeights { get; set; } = new();
+        public List<Gamba> GambaItemWeights { get; set; } = new();
         public bool GambaEnabled { get; set; } = false;
         public bool GambaPreferSmallerWheel { get; set; } = false;
         public int GambaCreditsMinimum { get; set; } = 0;

--- a/ICE/Enums/Missions.cs
+++ b/ICE/Enums/Missions.cs
@@ -1,0 +1,35 @@
+
+namespace ICE.Enums
+{
+    [Flags]
+    public enum MissionAttributes
+    {
+        None = 0,                  // Impossible to have no attributes. If None - we failed to parse the mission.
+
+        // --- Activity Type ---
+        Craft = 1,                 //
+        Gather = 2,                //
+        Fish = 4,                  //
+
+        // --- Constraints ---
+        Limited = 8,               // Supplies/Nodes/Bait
+
+        // --- Item/Focus Type ---
+        Collectables = 16,         // Collectables
+        ReducedItems = 32,         // Reduction
+        LargeFish = 64,           // Large Fish
+
+        // --- Scoring Method ---
+        ScoreTimeRemaining = 128,  // Time Attack (Speeeeeeed)
+        ScoreChains = 256,         // Chain Bonus
+        ScoreGatherersBoon = 512, // Gatherers Boon
+        ScoreLargestSize = 1024,   // Largest fish caught
+        ScoreVariety = 2048,       // Fish Variety
+
+        // --- Misc ---
+        Critical = 4096,          // Critical Mission
+        ProvisionalTimed = 8192,            // Timed Mission
+        ProvisionalWeather = 16384,          // Weather Mission
+        ProvisionalSequential = 32768,       // Sequential Mission
+    }
+}

--- a/ICE/Global.cs
+++ b/ICE/Global.cs
@@ -10,6 +10,7 @@ global using System.Linq;
 global using System.Numerics;
 global using System;
 global using ICE;
+global using ICE.Enums;
 global using ICE.Utilities;
 global using ICE.Scheduler;
 global using ICE.Scheduler.Handlers;

--- a/ICE/ICE.cs
+++ b/ICE/ICE.cs
@@ -211,7 +211,7 @@ public sealed partial class ICE : IDalamudPlugin
             if (info.Value == default) return;
             if (info.Value.MarkerId == 0) return;
 
-            Utils.SetGatheringRing(Svc.ClientState.TerritoryType, info.Value.X, info.Value.Y, info.Value.Radius, info.Value.Name);
+            Utils.SetGatheringRing(info.Value.TerritoryId, info.Value.X, info.Value.Y, info.Value.Radius, info.Value.Name);
         }
     }
 }

--- a/ICE/ICEDictornaryCreation.cs
+++ b/ICE/ICEDictornaryCreation.cs
@@ -100,6 +100,7 @@ public sealed partial class ICE
                 120 => MissionAttributes.Fish | MissionAttributes.ScoreLargestSize,
                 122 => MissionAttributes.Fish | MissionAttributes.Collectables,
                 >= 123 and <= 134 => MissionAttributes.Craft | MissionAttributes.Gather, // Dual class
+                >= 135 and <= 138 => MissionAttributes.Craft | MissionAttributes.Fish,  // Dual class
                 140 => MissionAttributes.Craft,
                 _ => MissionAttributes.None
             };

--- a/ICE/ICEDictornaryCreation.cs
+++ b/ICE/ICEDictornaryCreation.cs
@@ -78,10 +78,10 @@ public sealed partial class ICE
             int _y = marker.Unknown2 - 1024;
             int radius = marker.Unknown3;
 
-            MissionAttributes attributes = missionText switch // 99 to 140 are useful
+            MissionAttributes attributes = missionText switch
             {
-                99 or 101 => MissionAttributes.Craft | MissionAttributes.Limited,
-                100 or 102 => MissionAttributes.Craft | MissionAttributes.Limited | MissionAttributes.Collectables,
+                99 or 101 or 145 => MissionAttributes.Craft | MissionAttributes.Limited,
+                100 or 102 or 146 or 147 or 148 => MissionAttributes.Craft | MissionAttributes.Limited | MissionAttributes.Collectables,
                 103 => MissionAttributes.Gather | MissionAttributes.Limited,
                 104 => MissionAttributes.Gather | MissionAttributes.ScoreTimeRemaining,
                 105 or 139 => MissionAttributes.Gather,
@@ -101,7 +101,7 @@ public sealed partial class ICE
                 122 => MissionAttributes.Fish | MissionAttributes.Collectables,
                 >= 123 and <= 134 => MissionAttributes.Craft | MissionAttributes.Gather, // Dual class
                 >= 135 and <= 138 => MissionAttributes.Craft | MissionAttributes.Fish,  // Dual class
-                140 => MissionAttributes.Craft,
+                140 or 149 => MissionAttributes.Craft,
                 _ => MissionAttributes.None
             };
             attributes |= isCritical ? MissionAttributes.Critical : MissionAttributes.None;

--- a/ICE/ICEDictornaryCreation.cs
+++ b/ICE/ICEDictornaryCreation.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using FFXIVClientStructs.FFXIV.Client.Game.WKS;
-using ICE.Enums;
-using Lumina.Excel.Sheets;
 using static ICE.Utilities.CosmicHelper;
+using static ICE.Enums.MissionAttributes;
+using static ICE.Utilities.ExcelHelper;
 
 namespace ICE;
 
@@ -11,17 +11,6 @@ public sealed partial class ICE
     public static unsafe void DictionaryCreation()
     {
         MoonRecipies = [];
-        Svc.Data.GameData.Options.PanicOnSheetChecksumMismatch = false;
-
-        var MoonMissionSheet = Svc.Data.GetExcelSheet<WKSMissionUnit>();
-        var MoonRecipeSheet = Svc.Data.GetExcelSheet<WKSMissionRecipe>();
-        var RecipeSheet = Svc.Data.GetExcelSheet<Recipe>();
-        var ItemSheet = Svc.Data.GetExcelSheet<Item>();
-        var ExpSheet = Svc.Data.GetExcelSheet<WKSMissionReward>();
-        var ToDoSheet = Svc.Data.GetExcelSheet<WKSMissionToDo>();
-        var MoonItemInfo = Svc.Data.GetExcelSheet<WKSItemInfo>();
-        var MarkerSheet = Svc.Data.GetExcelSheet<WKSMissionMapMarker>();
-        var LeveAssignmentSheet = Svc.Data.GetExcelSheet<LeveAssignmentType>(); // using this for icons
 
         var wk = WKSManager.Instance();
 
@@ -80,34 +69,34 @@ public sealed partial class ICE
 
             MissionAttributes attributes = missionText switch
             {
-                99 or 101 or 145 => MissionAttributes.Craft | MissionAttributes.Limited,
-                100 or 102 or 146 or 147 or 148 => MissionAttributes.Craft | MissionAttributes.Limited | MissionAttributes.Collectables,
-                103 => MissionAttributes.Gather | MissionAttributes.Limited,
-                104 => MissionAttributes.Gather | MissionAttributes.ScoreTimeRemaining,
-                105 or 139 => MissionAttributes.Gather,
-                106 => MissionAttributes.Gather | MissionAttributes.ScoreChains,
-                107 => MissionAttributes.Gather | MissionAttributes.ScoreGatherersBoon,
-                108 => MissionAttributes.Gather | MissionAttributes.ScoreChains | MissionAttributes.ScoreGatherersBoon,
-                109 or 111 => MissionAttributes.Gather | MissionAttributes.Collectables,
-                110 => MissionAttributes.Gather | MissionAttributes.ReducedItems | MissionAttributes.ScoreTimeRemaining,
-                112 => MissionAttributes.Gather | MissionAttributes.ReducedItems,
-                113 => MissionAttributes.Fish | MissionAttributes.ScoreVariety | MissionAttributes.ScoreTimeRemaining,
-                114 or 115 => MissionAttributes.Fish | MissionAttributes.ScoreTimeRemaining,
-                116 => MissionAttributes.Fish | MissionAttributes.Limited | MissionAttributes.ScoreVariety,
-                117 => MissionAttributes.Fish | MissionAttributes.Limited | MissionAttributes.ScoreLargestSize,
-                118 => MissionAttributes.Fish | MissionAttributes.Limited | MissionAttributes.Collectables,
-                119 or 121 => MissionAttributes.Fish,
-                120 => MissionAttributes.Fish | MissionAttributes.ScoreLargestSize,
-                122 => MissionAttributes.Fish | MissionAttributes.Collectables,
-                >= 123 and <= 134 => MissionAttributes.Craft | MissionAttributes.Gather, // Dual class
-                >= 135 and <= 138 => MissionAttributes.Craft | MissionAttributes.Fish,  // Dual class
-                140 or 149 => MissionAttributes.Craft,
-                _ => MissionAttributes.None
+                99 or 101 or 145 => Craft | Limited,
+                100 or 102 or 146 or 147 or 148 => Craft | Limited | Collectables,
+                103 => Gather | Limited,
+                104 => Gather | ScoreTimeRemaining,
+                105 or 139 => Gather,
+                106 => Gather | ScoreChains,
+                107 => Gather | ScoreGatherersBoon,
+                108 => Gather | ScoreChains | ScoreGatherersBoon,
+                109 or 111 => Gather | Collectables,
+                110 => Gather | ReducedItems | ScoreTimeRemaining,
+                112 => Gather | ReducedItems,
+                113 => Fish | ScoreVariety | ScoreTimeRemaining,
+                114 or 115 => Fish | ScoreTimeRemaining,
+                116 => Fish | Limited | ScoreVariety,
+                117 => Fish | Limited | ScoreLargestSize,
+                118 => Fish | Limited | Collectables,
+                119 or 121 => Fish,
+                120 => Fish | ScoreLargestSize,
+                122 => Fish | Collectables,
+                >= 123 and <= 134 => Craft | Gather, // Dual class
+                >= 135 and <= 138 => Craft | Fish,  // Dual class
+                140 or 149 => Craft,
+                _ => None
             };
-            attributes |= isCritical ? MissionAttributes.Critical : MissionAttributes.None;
-            attributes |= weather != CosmicWeather.FairSkies ? MissionAttributes.ProvisionalWeather : MissionAttributes.None;
-            attributes |= time != 0 ? MissionAttributes.ProvisionalTimed : MissionAttributes.None;
-            attributes |= previousMissionId != 0 ? MissionAttributes.ProvisionalSequential : MissionAttributes.None;
+            attributes |= isCritical ? Critical : None;
+            attributes |= weather != CosmicWeather.FairSkies ? ProvisionalWeather : None;
+            attributes |= time != 0 ? ProvisionalTimed : None;
+            attributes |= previousMissionId != 0 ? ProvisionalSequential : None;
 
             if (CrafterJobList.Contains(JobId))
             {
@@ -128,7 +117,7 @@ public sealed partial class ICE
                 if (toDoRow.Unknown3 != 0 && !isCritical) // shouldn't be 0, 1st item entry
                 {
                     var item1Amount = toDoRow.Unknown6;
-                    var item1Id = MoonItemInfo.GetRow(toDoRow.Unknown3).Item;
+                    var item1Id = MoonItemInfoSheet.GetRow(toDoRow.Unknown3).Item;
                     var item1Name = ItemSheet.GetRow(item1Id).Name.ToString();
                     var item1RecipeRow = RecipeSheet.Where(e => e.ItemResult.RowId == item1Id)
                                                     .Where(e => e.RowId == MoonRecipeSheet.GetRow(RecipeId).Recipe[0].Value.RowId ||
@@ -163,7 +152,7 @@ public sealed partial class ICE
                 if (toDoRow.Unknown4 != 0) // 2nd item entry
                 {
                     var item2Amount = toDoRow.Unknown7;
-                    var item2Id = MoonItemInfo.GetRow(toDoRow.Unknown4).Item;
+                    var item2Id = MoonItemInfoSheet.GetRow(toDoRow.Unknown4).Item;
                     var item2Name = ItemSheet.GetRow(item2Id).Name.ToString();
 
                     var item2RecipeRow = RecipeSheet.Where(e => e.ItemResult.RowId == item2Id)
@@ -198,7 +187,7 @@ public sealed partial class ICE
                 if (toDoRow.Unknown5 != 0) // 3rd item entry
                 {
                     var item3Amount = toDoRow.Unknown8;
-                    var item3Id = MoonItemInfo.GetRow(toDoRow.Unknown5).Item;
+                    var item3Id = MoonItemInfoSheet.GetRow(toDoRow.Unknown5).Item;
                     var item3Name = ItemSheet.GetRow(item3Id).Name.ToString();
 
                     var item3RecipeRow = RecipeSheet.Where(e => e.ItemResult.RowId == item3Id)
@@ -260,7 +249,7 @@ public sealed partial class ICE
                 if (todoRow.Unknown3 != 0) // First item in the gathering list. Shouldn't be 0...
                 {
                     var minAmount = todoRow.Unknown6.ToInt();
-                    var itemInfoId = MoonItemInfo.GetRow(todoRow.Unknown3).Item;
+                    var itemInfoId = MoonItemInfoSheet.GetRow(todoRow.Unknown3).Item;
                     if (!GatherItems.ContainsKey(itemInfoId))
                     {
                         GatherItems.Add(itemInfoId, minAmount);
@@ -269,7 +258,7 @@ public sealed partial class ICE
                 if (todoRow.Unknown4 != 0) // First item in the gathering list. Shouldn't be 0...
                 {
                     var minAmount = todoRow.Unknown7.ToInt();
-                    var itemInfoId = MoonItemInfo.GetRow(todoRow.Unknown4).Item;
+                    var itemInfoId = MoonItemInfoSheet.GetRow(todoRow.Unknown4).Item;
                     if (!GatherItems.ContainsKey(itemInfoId))
                     {
                         GatherItems.Add(itemInfoId, minAmount);
@@ -278,7 +267,7 @@ public sealed partial class ICE
                 if (todoRow.Unknown5 != 0) // First item in the gathering list. Shouldn't be 0...
                 {
                     var minAmount = todoRow.Unknown8.ToInt();
-                    var itemInfoId = MoonItemInfo.GetRow(todoRow.Unknown5).Item;
+                    var itemInfoId = MoonItemInfoSheet.GetRow(todoRow.Unknown5).Item;
                     if (!GatherItems.ContainsKey(itemInfoId))
                     {
                         GatherItems.Add(itemInfoId, minAmount);
@@ -416,19 +405,19 @@ public sealed partial class ICE
     }
     private static MissionType GetMissionType(MissionListInfo mission)
     {
-        if (mission.Attributes.HasFlag(MissionAttributes.Critical))
+        if (mission.Attributes.HasFlag(Critical))
         {
             return MissionType.Critical;
         }
-        else if (mission.Attributes.HasFlag(MissionAttributes.ProvisionalTimed))
+        else if (mission.Attributes.HasFlag(ProvisionalTimed))
         {
             return MissionType.Timed;
         }
-        else if (mission.Attributes.HasFlag(MissionAttributes.ProvisionalWeather))
+        else if (mission.Attributes.HasFlag(ProvisionalWeather))
         {
             return MissionType.Weather;
         }
-        else if (mission.Attributes.HasFlag(MissionAttributes.ProvisionalSequential))
+        else if (mission.Attributes.HasFlag(ProvisionalSequential))
         {
             return MissionType.Sequential;
         }

--- a/ICE/Scheduler/Handlers/MissionHandler.cs
+++ b/ICE/Scheduler/Handlers/MissionHandler.cs
@@ -8,7 +8,7 @@ internal static class MissionHandler
         {
             if (CosmicHelper.CurrentLunarMission == 0)
                 return null;
-            if (CosmicHelper.CurrentMissionInfo.IsCriticalMission)
+            if (CosmicHelper.CurrentMissionInfo.Attributes.HasFlag(MissionAttributes.Critical))
             {
                 var (currentScore, _, _) = GetCurrentScores();
                 if (currentScore == 0)
@@ -35,7 +35,7 @@ internal static class MissionHandler
             uint currentScore = 0, silverScore = 0, goldScore = 0;
             if (GenericHelpers.TryGetAddonMaster<WKSMissionInfomation>("WKSMissionInfomation", out var z) && z.IsAddonReady)
                 {
-                if (CosmicHelper.CurrentMissionInfo.IsCriticalMission)
+                if (CosmicHelper.CurrentMissionInfo.Attributes.HasFlag(MissionAttributes.Critical))
                 {
                     
                     string _stages = MemoryHelper.ReadSeStringNullTerminated((nint)z.Addon->AtkValues[5].String.Value).GetText(); // Returns Current/Max - "0/2"

--- a/ICE/Scheduler/Tasks/TaskCrafting.cs
+++ b/ICE/Scheduler/Tasks/TaskCrafting.cs
@@ -269,7 +269,7 @@ namespace ICE.Scheduler.Tasks
         {
             if (EzThrottler.Throttle("WaitTillActuallyDone", 1000))
             {
-                if (CosmicHelper.CurrentMissionInfo.IsCriticalMission)
+                if (CosmicHelper.CurrentMissionInfo.Attributes.HasFlag(MissionAttributes.Critical))
                 {
                     if ((Svc.Condition[ConditionFlag.NormalConditions] || Svc.Condition[ConditionFlag.PreparingToCraft]) && !P.Artisan.IsBusy())
                     {

--- a/ICE/Scheduler/Tasks/TaskGather.cs
+++ b/ICE/Scheduler/Tasks/TaskGather.cs
@@ -3,8 +3,6 @@ using Dalamud.Game.ClientState.Objects.Types;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
-using Lumina.Excel;
-using Lumina.Excel.Sheets;
 using System.Collections.Generic;
 using static ECommons.UIHelpers.AddonMasterImplementations.AddonMaster;
 using static ICE.Utilities.CosmicHelper;
@@ -28,25 +26,15 @@ namespace ICE.Scheduler.Tasks
          * 
         */
 
-        private static ExcelSheet<Item>? ItemSheet;
-
         public static void TryEnqueueGathering()
         {
-            EnsureInit();
             if (CosmicHelper.CurrentLunarMission != 0)
                 MakeGatheringTask();
-        }
-
-        // Ensures that the sheets are loaded properly
-        private static void EnsureInit()
-        {
-            ItemSheet ??= Svc.Data.GetExcelSheet<Item>(); // Only need to grab once
         }
 
         // Version 2 of the gathering task. Trying to improve on it all...
         internal static void MakeGatheringTask()
         {
-            EnsureInit();
             var (currentScore, silverScore, goldScore) = GetCurrentScores();
 
             if (currentScore == 0 && silverScore == 0 && goldScore == 0)
@@ -599,8 +587,6 @@ namespace ICE.Scheduler.Tasks
 
         internal static bool? HaveEnoughMain()
         {
-            EnsureInit();
-
             if (CurrentLunarMission == 0)
                 return null;
 
@@ -618,7 +604,6 @@ namespace ICE.Scheduler.Tasks
 
         internal static (uint currentScore, uint silverScore, uint goldScore) GetCurrentScores()
         {
-            EnsureInit();
             if (GenericHelpers.TryGetAddonMaster<WKSMissionInfomation>("WKSMissionInfomation", out var z) && z.IsAddonReady)
             {
                 var goldScore = CosmicHelper.CurrentMissionInfo.GoldRequirement;

--- a/ICE/Ui/DebugWindow.cs
+++ b/ICE/Ui/DebugWindow.cs
@@ -594,6 +594,7 @@ internal class DebugWindow : Window
             ImGui.TableSetupColumn("RecipeID", ImGuiTableColumnFlags.WidthFixed, 100);
             ImGui.TableSetupColumn("Silver", ImGuiTableColumnFlags.WidthFixed, -1);
             ImGui.TableSetupColumn("Gold", ImGuiTableColumnFlags.WidthFixed, -1);
+            ImGui.TableSetupColumn("Attribute Flags", ImGuiTableColumnFlags.WidthFixed, -1);
             //ImGui.TableSetupColumn("Exp Type 1###MissionExpType1", ImGuiTableColumnFlags.WidthFixed, 100);
             //ImGui.TableSetupColumn("Exp Amount 1###MissionExpAmount1", ImGuiTableColumnFlags.WidthFixed, 100);
             //ImGui.TableSetupColumn("Exp Type 2###MissionExpType2", ImGuiTableColumnFlags.WidthFixed, 100);
@@ -672,6 +673,9 @@ internal class DebugWindow : Window
                 
                 ImGui.TableNextColumn();
                 ImGui.Text($"{entry.Value.GoldRequirement}");
+
+                ImGui.TableNextColumn();
+                ImGui.Text($"{entry.Value.Attributes}");
 
                 foreach (var expType in orderedExp)
                 {

--- a/ICE/Ui/DebugWindow.cs
+++ b/ICE/Ui/DebugWindow.cs
@@ -43,11 +43,6 @@ internal class DebugWindow : Window
 
     public override unsafe void Draw()
     {
-        var sheet = Svc.Data.GetExcelSheet<WKSMissionRecipe>();
-        var MissionSheet = Svc.Data.GetExcelSheet<WKSMissionUnit>();
-        var TodoSheet = Svc.Data.GetExcelSheet<WKSMissionToDo>();
-        var EvalSheet = Svc.Data.GetSubrowExcelSheet<WKSMissionToDoEvalutionItem>();
-
         if (ImGui.TreeNode("Player Info"))
         {
             if (ImGui.Button("Copy current POS"))
@@ -346,7 +341,7 @@ internal class DebugWindow : Window
 
         if (ImGui.TreeNode("Crafting Table"))
         {
-            var sheetRow = sheet.GetRow(27);
+            var sheetRow = ExcelHelper.MoonRecipeSheet.GetRow(27);
 
             Table();
 
@@ -363,9 +358,9 @@ internal class DebugWindow : Window
         if (ImGui.TreeNode("Gathering Table"))
         {
             uint missionId = 418;
-            var Todo = MissionSheet.GetRow(missionId).Unknown7;
-            var PotentionalValue = TodoSheet.GetRow(Todo).Unknown10;
-            var EvaluationItem = EvalSheet.GetSubrowAt(PotentionalValue, 0);
+            var Todo = ExcelHelper.MoonMissionSheet.GetRow(missionId).Unknown7;
+            var PotentionalValue = ExcelHelper.ToDoSheet.GetRow(Todo).Unknown10;
+            var EvaluationItem = ExcelHelper.EvalSheet.GetSubrowAt(PotentionalValue, 0);
 
 
             ImGui.Text($"Mission: 418 | Todo Spot: {Todo}");
@@ -383,7 +378,6 @@ internal class DebugWindow : Window
             ImGui.Text($"Current Mission: {CosmicHelper.CurrentLunarMission}");
             ImGui.Text($"Artisan Endurance: {P.Artisan.GetEnduranceStatus()}");
 
-            var ExpSheet = Svc.Data.GetExcelSheet<WKSMissionReward>();
             //  4 - Col 2  - Unknown 7
             //  8 - Col 3  - Unknown 0
             // 10 - Col 4  - Unknown 1
@@ -454,8 +448,7 @@ internal class DebugWindow : Window
 
             }
 
-            var MoonMissionSheet = Svc.Data.GetExcelSheet<WKSMissionUnit>();
-            var moonRow = MoonMissionSheet.GetRow(26);
+            var moonRow = ExcelHelper.MoonMissionSheet.GetRow(26);
             ImGui.Text($"{moonRow.Unknown1} \n" +
                        $"{moonRow.Unknown2} \n" +
                        $"{moonRow.Unknown3} \n" +
@@ -477,8 +470,7 @@ internal class DebugWindow : Window
                        $"{moonRow.Unknown19} \n" +
                        $"{moonRow.Unknown20} \n");
 
-            var toDoSheet = Svc.Data.GetExcelSheet<WKSMissionToDo>();
-            var toDoRow = toDoSheet.GetRow(168);
+            var toDoRow = ExcelHelper.ToDoSheet.GetRow(168);
 
             ImGui.Text($"     TODO         \n" +
                        $"{toDoRow.Unknown0}\n" +
@@ -502,8 +494,7 @@ internal class DebugWindow : Window
                        $"{toDoRow.Unknown18}\n");
 
             ImGui.Spacing();
-            var moonItemSheet = Svc.Data.GetExcelSheet<WKSItemInfo>();
-            var moonItemRow = moonItemSheet.GetRow(523);
+            var moonItemRow = ExcelHelper.MoonItemInfoSheet.GetRow(523);
 
             ImGui.Text($"  WKS Item Info\n" +
                        $"{moonItemRow.Item}\n" +
@@ -544,7 +535,7 @@ internal class DebugWindow : Window
         {
             ImGui.InputInt("TableId", ref TableRow);
 
-            var MapInfo = Svc.Data.GetExcelSheet<WKSMissionMapMarker>();
+            var MapInfo = ExcelHelper.MarkerSheet;
 
             if (ImGui.Button($"Test Radius"))
             {
@@ -579,7 +570,7 @@ internal class DebugWindow : Window
 
     private unsafe void Table()
     {
-        var itemSheet = Svc.Data.GetExcelSheet<Item>();
+        var itemSheet = ExcelHelper.ItemSheet;
         ImGui.SetNextItemWidth(250);
         ImGui.InputText("Search by Name", ref CraftingTableSearchText, 100);
 
@@ -705,7 +696,6 @@ internal class DebugWindow : Window
 
     private void Table2()
     {
-        var MainMissionSheet = Svc.Data.GetExcelSheet<WKSMissionUnit>();
         ImGui.SetNextItemWidth(250);
         ImGui.InputText("Search by Name", ref RecipeTableSearchText, 100);
 
@@ -762,7 +752,7 @@ internal class DebugWindow : Window
 
     private void Table3()
     {
-        var itemName = Svc.Data.GetExcelSheet<Item>();
+        var itemName = ExcelHelper.ItemSheet;
 
         if (ImGui.BeginTable("Gathering Mission Dictionary", 7, ImGuiTableFlags.RowBg | ImGuiTableFlags.Borders | ImGuiTableFlags.Resizable))
         {

--- a/ICE/Ui/DebugWindow.cs
+++ b/ICE/Ui/DebugWindow.cs
@@ -555,7 +555,7 @@ internal class DebugWindow : Window
                 int _radius = MapInfo.GetRow((uint)TableRow).Unknown3.ToInt();
                 PluginLog.Debug($"X: {_x} Y: {_y} Radius: {_radius}");
 
-                Utils.SetGatheringRing(agent->CurrentTerritoryId, _x, _y, _radius);
+                Utils.SetGatheringRing(1237, _x, _y, _radius);
             }
             ImGui.SetNextItemWidth(125);
             ImGui.InputInt("Map X (Sheet)", ref posX);
@@ -690,7 +690,7 @@ internal class DebugWindow : Window
                 {
                     if (ImGui.Button($"Flag###Flag-{entry.Key}"))
                     {
-                        Utils.SetGatheringRing(agent->CurrentTerritoryId, entry.Value.X, entry.Value.Y, entry.Value.Radius);
+                        Utils.SetGatheringRing(entry.Value.TerritoryId, entry.Value.X, entry.Value.Y, entry.Value.Radius);
                     }
                 }
             }

--- a/ICE/Ui/MainWindowV2.cs
+++ b/ICE/Ui/MainWindowV2.cs
@@ -339,29 +339,29 @@ namespace ICE.Ui
                 IEnumerable<KeyValuePair<uint, MissionListInfo>> criticalMissions =
                     MissionInfoDict
                 .Where(m => m.Value.JobId == selectedJob)
-                .Where(m => m.Value.IsCriticalMission);
+                .Where(m => m.Value.Attributes.HasFlag(MissionAttributes.Critical));
                 criticalMissions = sortOptions.FirstOrDefault(s => s.Id == SortOption).SortFunc(criticalMissions);
                 bool criticalGather = criticalMissions.Any(g => GatheringJobList.Contains((int)g.Value.JobId) || GatheringJobList.Contains((int)g.Value.JobId2));
 
                 IEnumerable<KeyValuePair<uint, MissionListInfo>> weatherRestrictedMissions =
                         MissionInfoDict
                             .Where(m => m.Value.JobId == selectedJob || m.Value.JobId2 == selectedJob)
-                            .Where(m => m.Value.Weather != CosmicWeather.FairSkies)
-                            .Where(m => !m.Value.IsCriticalMission);
+                            .Where(m => m.Value.Attributes.HasFlag(MissionAttributes.ProvisionalWeather))
+                            .Where(m => !m.Value.Attributes.HasFlag(MissionAttributes.Critical));
                 bool weatherGather = weatherRestrictedMissions.Any(g => GatheringJobList.Contains((int)g.Value.JobId) || GatheringJobList.Contains((int)g.Value.JobId2));
                 weatherRestrictedMissions = sortOptions.FirstOrDefault(s => s.Id == SortOption).SortFunc(weatherRestrictedMissions);
 
                 IEnumerable<KeyValuePair<uint, MissionListInfo>> timeRestrictedMissions =
                         MissionInfoDict
                             .Where(m => m.Value.JobId == selectedJob)
-                            .Where(m => m.Value.Time != 0);
+                            .Where(m => m.Value.Attributes.HasFlag(MissionAttributes.ProvisionalTimed));
                 bool timeGather = timeRestrictedMissions.Any(g => GatheringJobList.Contains((int)g.Value.JobId) || GatheringJobList.Contains((int)g.Value.JobId2));
                 timeRestrictedMissions = sortOptions.FirstOrDefault(s => s.Id == SortOption).SortFunc(timeRestrictedMissions);
 
                 IEnumerable<KeyValuePair<uint, MissionListInfo>> sequentialMissions =
                         MissionInfoDict
                             .Where(m => m.Value.JobId == selectedJob)
-                            .Where(m => m.Value.PreviousMissionID != 0);
+                            .Where(m => m.Value.Attributes.HasFlag(MissionAttributes.ProvisionalSequential));
                 bool sequentialGather = sequentialMissions.Any(g => GatheringJobList.Contains((int)g.Value.JobId) || GatheringJobList.Contains((int)g.Value.JobId2));
                 sequentialMissions = sortOptions.FirstOrDefault(s => s.Id == SortOption).SortFunc(sequentialMissions);
 
@@ -408,10 +408,10 @@ namespace ICE.Ui
                         MissionInfoDict
                             .Where(m => m.Value.JobId == selectedJob || m.Value.JobId2 == selectedJob)
                             .Where(m => (m.Value.Rank == rank.RankId) || (rank.RankName == "A" && ARankIds.Contains(m.Value.Rank)))
-                            .Where(m => !m.Value.IsCriticalMission)
-                            .Where(m => m.Value.Time == 0)
-                            .Where(m => m.Value.PreviousMissionID == 0)
-                            .Where(m => m.Value.Weather == CosmicWeather.FairSkies);
+                            .Where(m => !m.Value.Attributes.HasFlag(MissionAttributes.Critical))
+                            .Where(m => m.Value.Attributes.HasFlag(MissionAttributes.ProvisionalTimed))
+                            .Where(m => m.Value.Attributes.HasFlag(MissionAttributes.ProvisionalSequential))
+                            .Where(m => m.Value.Attributes.HasFlag(MissionAttributes.ProvisionalWeather));
                     missions = sortOptions.FirstOrDefault(s => s.Id == SortOption).SortFunc(missions);
 
                     bool missionGather = missions.Any(g => GatheringJobList.Contains((int)g.Value.JobId) || GatheringJobList.Contains((int)g.Value.JobId2));
@@ -841,7 +841,7 @@ namespace ICE.Ui
                         ImGui.Text(FontAwesomeIcon.Flag.ToIconString());
                         ImGui.PopFont();
                         if (ImGui.IsItemClicked())
-                            Utils.SetGatheringRing(Svc.ClientState.TerritoryType, info.X, info.Y, info.Radius, info.Name);
+                            Utils.SetGatheringRing(info.TerritoryId, info.X, info.Y, info.Radius, info.Name);
                     }
 
                     // Column 3: Credits
@@ -877,7 +877,7 @@ namespace ICE.Ui
                         modes = ["Manual"];
                         selectedModes = [mission.ManualMode];
                     }
-                    else if ((GatheringJobList.Contains((int)entry.Value.JobId) && gatherMissionType == 3) || entry.Value.IsCriticalMission)
+                    else if ((GatheringJobList.Contains((int)entry.Value.JobId) && gatherMissionType == 3) || entry.Value.Attributes.HasFlag(MissionAttributes.Critical))
                     {
                         modes = ["ASAP", "Manual"];
                         selectedModes = [mission.TurnInASAP, mission.ManualMode];
@@ -915,7 +915,7 @@ namespace ICE.Ui
                         {
                             mission.ManualMode = true;
                         }
-                        else if ((GatheringJobList.Contains((int)entry.Value.JobId) && gatherMissionType == 3) || entry.Value.IsCriticalMission)
+                        else if ((GatheringJobList.Contains((int)entry.Value.JobId) && gatherMissionType == 3) || entry.Value.Attributes.HasFlag(MissionAttributes.Critical))
                         {
                             mission.TurnInASAP = true;
                             mission.ManualMode = selectedModes[1];

--- a/ICE/Utilities/AddonHelper.cs
+++ b/ICE/Utilities/AddonHelper.cs
@@ -13,7 +13,7 @@ public static class AddonHelper
         int[] basicCrafts = [1008, 1, 170, 663, 302, 464, 1101, 901];
         uint recipeId = (uint)basicCrafts[(int)PlayerHelper.GetClassJobId()-8];
 
-        AgentRecipeNote.Instance()->OpenRecipeByRecipeId(Svc.Data.GetExcelSheet<Recipe>().GetRow(recipeId).RowId);
+        AgentRecipeNote.Instance()->OpenRecipeByRecipeId(ExcelHelper.RecipeSheet.GetRow(recipeId).RowId);
     }
     public static unsafe bool IsAddonActive(string AddonName) // Used to see if the addon is active/ready to be fired on
     {

--- a/ICE/Utilities/Cosmic/MissionData.cs
+++ b/ICE/Utilities/Cosmic/MissionData.cs
@@ -45,7 +45,7 @@ public static unsafe partial class CosmicHelper
         public uint JobId3 { get; set; } = 0;
         public uint ToDoSlot { get; set; }
         public uint Rank { get; set; }
-        public bool IsCriticalMission { get; set; }
+        public MissionAttributes Attributes { get; set; }
         public uint TimeLimit { get; set; }
         public uint Time { get; set; }
         public CosmicWeather Weather { get; set; }
@@ -56,10 +56,10 @@ public static unsafe partial class CosmicHelper
         public uint LunarCredit { get; set; }
         public uint PreviousMissionID { get; set; }
         public uint MarkerId { get; set; }
+        public uint TerritoryId { get; set; }
         public int X { get; set; }
         public int Y { get; set; }
         public int Radius { get; set; }
-
         public List<(int Type, int Amount)> ExperienceRewards { get; set; }
     }
 

--- a/ICE/Utilities/ExcelHelper.cs
+++ b/ICE/Utilities/ExcelHelper.cs
@@ -1,18 +1,40 @@
 using Lumina.Excel;
 using Lumina.Excel.Sheets;
 
+namespace ICE.Utilities;
 internal static class ExcelHelper
 {
     internal static ExcelSheet<Item>? ItemSheet;
     internal static ExcelSheet<Recipe>? RecipeSheet;
     internal static ExcelSheet<Weather>? WeatherSheet;
+    internal static ExcelSheet<TerritoryType>? TerritorySheet;
+    internal static ExcelSheet<ClassJob>? ClassJobSheet;
     internal static ExcelSheet<WKSDevGrade>? DevGrade;
+    internal static ExcelSheet<WKSMissionUnit>? MoonMissionSheet;
+    internal static ExcelSheet<WKSMissionRecipe>? MoonRecipeSheet;
+    internal static ExcelSheet<WKSMissionReward>? ExpSheet;
+    internal static ExcelSheet<WKSMissionToDo>? ToDoSheet;
+    internal static ExcelSheet<WKSItemInfo>? MoonItemInfoSheet;
+    internal static ExcelSheet<WKSMissionMapMarker>? MarkerSheet;
+    internal static ExcelSheet<LeveAssignmentType>? LeveAssignmentSheet;
+    internal static SubrowExcelSheet<WKSMissionToDoEvalutionItem>? EvalSheet;
 
-    public static void Init() // Only need to grab once, it won't change
+    public static void Init() // Only need to grab once, they won't change
     {
+        Svc.Data.GameData.Options.PanicOnSheetChecksumMismatch = false;
         ItemSheet ??= Svc.Data.GetExcelSheet<Item>();
         RecipeSheet ??= Svc.Data.GetExcelSheet<Recipe>();
         WeatherSheet ??= Svc.Data.GetExcelSheet<Weather>();
+        TerritorySheet ??= Svc.Data.GetExcelSheet<TerritoryType>();
+        ClassJobSheet ??= Svc.Data.GetExcelSheet<ClassJob>();
         DevGrade ??= Svc.Data.GetExcelSheet<WKSDevGrade>();
+        MoonMissionSheet ??= Svc.Data.GetExcelSheet<WKSMissionUnit>();
+        MoonRecipeSheet ??= Svc.Data.GetExcelSheet<WKSMissionRecipe>();
+        ExpSheet ??= Svc.Data.GetExcelSheet<WKSMissionReward>();
+        ToDoSheet ??= Svc.Data.GetExcelSheet<WKSMissionToDo>();
+        MoonItemInfoSheet ??= Svc.Data.GetExcelSheet<WKSItemInfo>();
+        MarkerSheet ??= Svc.Data.GetExcelSheet<WKSMissionMapMarker>();
+        LeveAssignmentSheet ??= Svc.Data.GetExcelSheet<LeveAssignmentType>(); // using this for icons
+        EvalSheet ??= Svc.Data.GetSubrowExcelSheet<WKSMissionToDoEvalutionItem>();
     }
 }

--- a/ICE/Utilities/PlayerHelper.cs
+++ b/ICE/Utilities/PlayerHelper.cs
@@ -30,7 +30,7 @@ public class PlayerHelper
     internal static unsafe short GetCurrentLevelFromSheet(Job? job = null)
     {
         PlayerState* playerState = PlayerState.Instance();
-        return playerState->ClassJobLevels[Svc.Data.GetExcelSheet<ClassJob>().GetRowOrDefault((uint)(job ?? (Player.Available ? Player.Object.GetJob() : 0)))?.ExpArrayIndex ?? 0];
+        return playerState->ClassJobLevels[ExcelHelper.ClassJobSheet.GetRowOrDefault((uint)(job ?? (Player.Available ? Player.Object.GetJob() : 0)))?.ExpArrayIndex ?? 0];
     }
 
     public static bool IsInCosmicZone() => IsInSinusArdorum();

--- a/ICE/Utilities/Utils.cs
+++ b/ICE/Utilities/Utils.cs
@@ -5,7 +5,6 @@ using ECommons.Reflection;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.UI.Agent;
-using Lumina.Excel.Sheets;
 
 namespace ICE.Utilities;
 
@@ -20,8 +19,7 @@ public static unsafe class Utils
 
     public static unsafe void SetFlagForNPC(uint territoryId, float x, float y)
     {
-        var terSheet = Svc.Data.GetExcelSheet<TerritoryType>();
-        var map = terSheet.GetRow(territoryId).Map.Value;
+        var map = ExcelHelper.TerritorySheet.GetRow(territoryId).Map.Value;
 
         var agent = AgentMap.Instance();
 
@@ -92,8 +90,7 @@ public static unsafe class Utils
 
     public static unsafe void SetGatheringRing(uint territoryId, int x, int y, int radius, string? tooltip = "Node Location")
     {
-        var terSheet = Svc.Data.GetExcelSheet<TerritoryType>();
-        var map = terSheet.GetRow(territoryId).Map.Value;
+        var map = ExcelHelper.TerritorySheet.GetRow(territoryId).Map.Value;
         var agent = AgentMap.Instance();
         
         Vector2 pos = MapToWorld(new Vector2(x, y), map.SizeFactor, map.OffsetX, map.OffsetY);
@@ -103,6 +100,6 @@ public static unsafe class Utils
         agent->SetFlagMapMarker(territoryId, map.RowId, x, y);
         agent->TempMapMarkerCount = 0;
         agent->AddGatheringTempMarker(x, y, radius, tooltip: tooltip);
-        agent->OpenMap(map.RowId, territoryId, tooltip, FFXIVClientStructs.FFXIV.Client.UI.Agent.MapType.GatheringLog);
+        agent->OpenMap(map.RowId, territoryId, tooltip, MapType.GatheringLog);
     }
 }


### PR DESCRIPTION
Sets up attributes on missions that we can later reference in Score and other UI to know what kind of mission it is (Without hardcoding specific mission IDs).

Also adds a (temporarily) hardcoded TerritoryID.