### PR TITLE
Develop

### DIFF
--- a/ICE/ICE.cs
+++ b/ICE/ICE.cs
@@ -78,7 +78,7 @@ public sealed partial class ICE : IDalamudPlugin
         Svc.PluginInterface.UiBuilder.Draw += windowSystem.Draw;
         Svc.PluginInterface.UiBuilder.OpenMainUi += () =>
         {
-            mainWindow.IsOpen = true;
+            mainWindow2.IsOpen = true;
         };
         Svc.PluginInterface.UiBuilder.OpenConfigUi += () =>
         {

--- a/ICE/ICE.csproj
+++ b/ICE/ICE.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Dalamud.NET.Sdk/12.0.2">
 
   <PropertyGroup>
-    <Version>0.0.0.37</Version>
+    <Version>0.0.0.38</Version>
     <Description>Who said we couldn't explore the moon!.</Description>
     <PackageProjectUrl>https://github.com/goatcorp/ICE</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/ICE/ICE.csproj
+++ b/ICE/ICE.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Dalamud.NET.Sdk/12.0.2">
 
   <PropertyGroup>
-    <Version>0.0.0.33</Version>
+    <Version>0.0.0.34</Version>
     <Description>Who said we couldn't explore the moon!.</Description>
     <PackageProjectUrl>https://github.com/goatcorp/ICE</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/ICE/ICE.csproj
+++ b/ICE/ICE.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Dalamud.NET.Sdk/12.0.2">
 
   <PropertyGroup>
-    <Version>0.0.0.36</Version>
+    <Version>0.0.0.37</Version>
     <Description>Who said we couldn't explore the moon!.</Description>
     <PackageProjectUrl>https://github.com/goatcorp/ICE</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/ICE/ICE.csproj
+++ b/ICE/ICE.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Dalamud.NET.Sdk/12.0.2">
 
   <PropertyGroup>
-    <Version>0.0.0.34</Version>
+    <Version>0.0.0.36</Version>
     <Description>Who said we couldn't explore the moon!.</Description>
     <PackageProjectUrl>https://github.com/goatcorp/ICE</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/ICE/ICE.csproj
+++ b/ICE/ICE.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Dalamud.NET.Sdk/12.0.2">
 
   <PropertyGroup>
-    <Version>0.0.0.38</Version>
+    <Version>0.0.0.39</Version>
     <Description>Who said we couldn't explore the moon!.</Description>
     <PackageProjectUrl>https://github.com/goatcorp/ICE</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/ICE/ICEDictornaryCreation.cs
+++ b/ICE/ICEDictornaryCreation.cs
@@ -24,7 +24,6 @@ public sealed partial class ICE
             string LeveName = item.Item.ToString();
             LeveName = LeveName.Replace("<nbsp>", " ");
             LeveName = LeveName.Replace("<->", "");
-            Utils.missionLength = Math.Max(Utils.missionLength, ImGui.CalcTextSize(LeveName).X);
 
             if (LeveName == "")
                 continue;
@@ -453,14 +452,6 @@ public sealed partial class ICE
                 C.Save();
             }
         }
-
-        // Updating the column lengths based on the text size
-        Utils.enableColumnLength = ImGui.CalcTextSize("Enabled").X + 10f;
-        Utils.IDLength = ImGui.CalcTextSize("ID").X + 10f;
-        Utils.enableColumnLength = ImGui.CalcTextSize("Enabled").X + 10f;  // Add buffer
-        Utils.cosmicLength = ImGui.CalcTextSize("Cosmo").X + 5f;
-        Utils.lunarLength = ImGui.CalcTextSize("Lunar").X + 5f;
-        Utils.XPLength = (ImGui.CalcTextSize("III").X + 5f) * 4f;
     }
     private static MissionType GetMissionType(MissionListInfo mission)
     {

--- a/ICE/Scheduler/Handlers/GenericManager.cs
+++ b/ICE/Scheduler/Handlers/GenericManager.cs
@@ -46,47 +46,17 @@ namespace ICE.Scheduler.Handlers
 
         internal static void Tick()
         {
-            if (SchedulerMain.State != IceState.Idle)
+            if (SchedulerMain.State.HasFlag(IceState.Gather))
             {
-                //by Taurenkey https://github.com/PunishXIV/PandorasBox/blob/24a4352f5b01751767c7ca7f1d4b48369be98711/PandorasBox/Features/UI/AutoSelectTurnin.cs
+                var featureEnabled = (P.Pandora.GetFeatureEnabled("Pandora Quick Gather") ?? false);
 
-                var featureEnabled = (P.Pandora.GetFeatureEnabled("Auto-select Turn-ins") ?? false);
-                var configEnabled = (P.Pandora.GetConfigEnabled("Auto-select Turn-ins", "AutoSelect") ?? false);
-
-                var isenabled = featureEnabled && configEnabled;
-
-                if (!isenabled)
+                if (featureEnabled)
                 {
-                    if (featureEnabled && !configEnabled)
+                    if (EzThrottler.Throttle("Disabling Pandora Gathering", 1000))
                     {
-                        if (EzThrottler.Throttle("Enabling AutoSelect", 1000))
-                        {
-                            P.Pandora.PauseFeature("Auto-select Turn-ins", 1100);
-                        }
-                    }
-
-                    if (GenericHelpers.TryGetAddonByName<AddonRequest>("Request", out var addon3))
-                    {
-                        for (var i = 1; i <= addon3->EntryCount; i++)
-                        {
-                            if (SlotsFilled.Contains(addon3->EntryCount)) ConfirmOrAbort(addon3);
-                            if (SlotsFilled.Contains(i)) return;
-                            var val = i;
-                            TaskManager.DelayNext($"ClickTurnin{val}", 10);
-                            TaskManager.Enqueue(() => TryClickItem(addon3, val));
-                        }
-                    }
-                    else
-                    {
-                        SlotsFilled.Clear();
-                        TaskManager.Abort();
+                        P.Pandora.PauseFeature("Pandora Quick Gather", 1000);
                     }
                 }
-            }
-            else
-            {
-                // Clear slots when not ticking to prevent unbounded growth
-                SlotsFilled.Clear();
             }
         }
     }

--- a/ICE/Scheduler/Tasks/TaskGather.cs
+++ b/ICE/Scheduler/Tasks/TaskGather.cs
@@ -90,7 +90,7 @@ namespace ICE.Scheduler.Tasks
                 {
 
                     Vector3 nodeLoc = GatheringUtil.MoonNodeInfoList.Where(x => x.NodeId == nodeId).FirstOrDefault().LandZone;
-                    if (PlayerHelper.GetDistanceToPlayer(nodeLoc) > 2)
+                    if (PlayerHelper.GetDistanceToPlayer(nodeLoc) > 1.5f)
                     {
                         // Seen that the distance between you and the node is greater than 2, pathfinding
                         P.TaskManager.Enqueue(() => PathToNode(nodeLoc), "Pathing to node");
@@ -406,14 +406,14 @@ namespace ICE.Scheduler.Tasks
         /// <param name="id"></param>
         internal static bool? PathToNode(Vector3 nodeLoc)
         {
-            if (PlayerHelper.GetDistanceToPlayer(nodeLoc) > 2 && !P.Navmesh.IsRunning())
+            if (PlayerHelper.GetDistanceToPlayer(nodeLoc) > 1.5f && !P.Navmesh.IsRunning())
             {
                 if (EzThrottler.Throttle("Throttling pathfind"))
                 {
                     P.Navmesh.PathfindAndMoveTo(nodeLoc, false);
                 }
             }
-            else if (PlayerHelper.GetDistanceToPlayer(nodeLoc) < 2)
+            else if (PlayerHelper.GetDistanceToPlayer(nodeLoc) < 1.5f)
             {
                 if (P.Navmesh.IsRunning())
                 {

--- a/ICE/Scheduler/Tasks/TaskGather.cs
+++ b/ICE/Scheduler/Tasks/TaskGather.cs
@@ -3,6 +3,7 @@ using Dalamud.Game.ClientState.Objects.Types;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using ICE.Utilities;
 using System.Collections.Generic;
 using static ECommons.UIHelpers.AddonMasterImplementations.AddonMaster;
 using static ICE.Utilities.CosmicHelper;
@@ -292,79 +293,79 @@ namespace ICE.Scheduler.Tasks
                                         int boonChance = item.BoonChance;
                                         if (BoonIncrease2Bool(boonChance, gBuffs) && !missingDur)
                                         {
+                                            IceLogging.Debug("Activating Boon% 2");
                                             useAction = true;
                                             if (EzThrottler.Throttle("Boon2 Action Usage"))
                                             {
-                                                IceLogging.Debug("Activating Boon% 2");
                                                 GatherBuffs(Boon2);
                                             }
                                             return;
                                         }
                                         else if (BoonIncrease1Bool(boonChance, gBuffs) && !missingDur)
                                         {
+                                            IceLogging.Debug("Activating Boon% 1");
                                             useAction = true;
                                             if (EzThrottler.Throttle("Boon1 Action Usage"))
                                             {
-                                                IceLogging.Debug("Activating Boon% 1");
                                                 GatherBuffs(Boon1);
                                             }
                                             return;
                                         }
                                         else if (TidingsBool(gBuffs))
                                         {
+                                            IceLogging.Debug("Activating Bonus Item from Tidings");
                                             useAction = true;
                                             if (EzThrottler.Throttle("Tidings Action Usage") && !missingDur)
                                             {
-                                                IceLogging.Debug("Activating Bonus Item from Tidings");
                                                 GatherBuffs(Tidings);
                                             }
                                             return;
                                         }
-                                        else if (Yield2Bool(gBuffs))
+                                        else if (Yield2Bool(gBuffs) && !missingDur)
                                         {
+                                            IceLogging.Debug("Activating Kings Yield II [or equivelent]");
                                             useAction = true;
                                             if (EzThrottler.Throttle("Using Yield2 Action Usage") && !missingDur)
                                             {
-                                                IceLogging.Debug("Activating Kings Yield II [or equivelent]");
                                                 GatherBuffs(Yield2);
                                             }
                                             return;
                                         }
-                                        else if (Yield1Bool(gBuffs))
+                                        else if (Yield1Bool(gBuffs) && !missingDur)
                                         {
+                                            IceLogging.Debug("Activating Kings Yield I [or equivelent]");
                                             useAction = true;
                                             if (EzThrottler.Throttle("Using Yield1 Action Usage") && !missingDur)
                                             {
-                                                IceLogging.Debug("Activating Kings Yield II [or equivelent]");
                                                 GatherBuffs(Yield1);
                                             }
                                             return;
                                         }
                                         else if (BYield2Bool(gBuffs))
                                         {
+                                            IceLogging.Debug("Activating Bountiful Yield/Harvest II");
                                             useAction = true;
                                             if (EzThrottler.Throttle("Using Bountiful Yield Action"))
                                             {
-                                                IceLogging.Debug("Activating Bountiful Yield/Harvest II");
                                                 GatherBuffs(BYieldII);
                                             }
                                         }
                                         else if (BonusIntegrityBool(missingDur))
                                         {
+                                            IceLogging.Debug("Activating Bonus Yield Button");
                                             useAction = true;
                                             if (EzThrottler.Throttle("Using Bonus Intregrity Usage"))
                                             {
-                                                IceLogging.Debug("Activating Bonus Yield Button");
                                                 GatherBuffs(BonusInteg);
                                             }
                                             return;
                                         }
                                         else if (IntegrityBool(missingDur, gBuffs))
                                         {
+                                            IceLogging.Debug("Activing Integrity Increase Button [Hoping for bonus Integ]");
                                             useAction = true;
                                             if (EzThrottler.Throttle("Missing Dur, using action"))
                                             {
-                                                IceLogging.Debug("Activing Integrity Increase Button [Hoping for bonus Integ]");
                                                 GatherBuffs(IntegInc);
                                             }
                                             return;

--- a/ICE/Scheduler/Tasks/TaskGather.cs
+++ b/ICE/Scheduler/Tasks/TaskGather.cs
@@ -194,7 +194,6 @@ namespace ICE.Scheduler.Tasks
                                     {
                                         #nullable disable
                                         int boonChance = item.BoonChance;
-                                        IceLogging.Debug($"Boon Increase 2: {BoonIncrease2Bool(boonChance, gBuffs)} && Missing durability: {missingDur}");
                                         if (BoonIncrease2Bool(boonChance, gBuffs) && !missingDur)
                                         {
                                             IceLogging.Debug($"Should be activating buff...", true);
@@ -288,12 +287,11 @@ namespace ICE.Scheduler.Tasks
                                     }
                                     else if (!hasAllItems && item.ItemID == itemToGather)
                                     {
-                                        IceLogging.Debug($"Condion F Met", true);
+                                        IceLogging.Debug($"[Condition F] Mission is aiming to gather: {itemToGather}", true);
+
                                         int boonChance = item.BoonChance;
-                                        IceLogging.Debug($"Boon Increase 2: {BoonIncrease2Bool(boonChance, gBuffs)} && Missing durability: {missingDur}");
                                         if (BoonIncrease2Bool(boonChance, gBuffs) && !missingDur)
                                         {
-                                            IceLogging.Debug($"Should be activating buff...", true);
                                             useAction = true;
                                             if (EzThrottler.Throttle("Boon2 Action Usage"))
                                             {

--- a/ICE/Ui/MainWindowV2.cs
+++ b/ICE/Ui/MainWindowV2.cs
@@ -970,13 +970,6 @@ namespace ICE.Ui
                         unsupported = true;
                     }
 
-#if RELEASE
-                    if (dualclass)
-                    {
-                        unsupported = true;
-                    }
-#endif
-
                     if (unsupported && hideUnsupported)
                         continue;
 

--- a/ICE/Ui/MainWindowV2.cs
+++ b/ICE/Ui/MainWindowV2.cs
@@ -364,9 +364,7 @@ namespace ICE.Ui
             // ------------------------------------------
             ImGui.NextColumn();
 
-            middlePanelWidth += Utils.missionLength + 20f;
-            middlePanelWidth += Utils.enableColumnLength;
-            middlePanelWidth += Utils.IDLength;
+            middlePanelWidth += 250;
             if (showCredits)
             {
                 middlePanelWidth += Utils.cosmicLength;
@@ -378,10 +376,10 @@ namespace ICE.Ui
             }
             if (showNotes)
             {
-                middlePanelWidth += 200;
+                middlePanelWidth += Utils.MissionNotesLength + 100;
             }
             // Buffer room for the scrollbar
-            middlePanelWidth += 20;
+            middlePanelWidth += 100;
             ImGui.SetColumnWidth(1, middlePanelWidth);
 
             if (ImGui.BeginChild("###MissionList", new Vector2(0, childHeight), true))
@@ -888,6 +886,13 @@ namespace ICE.Ui
                 float col5Width = ImGui.CalcTextSize("Lunar").X + 5f;
                 float colXPWidth = ImGui.CalcTextSize("III").X + 5f;
 
+                // Updating the column lengths based on the text size
+                Utils.enableColumnLength = col1Width;
+                Utils.IDLength = col2Width;
+                Utils.cosmicLength = col4Width;
+                Utils.lunarLength = col5Width;
+                Utils.XPLength = colXPWidth * 4f;
+
                 ImGui.TableSetupColumn("###EnableCheckbox", ImGuiTableColumnFlags.WidthFixed, col1Width);
                 ImGui.TableSetupColumn("###MissionIDs", ImGuiTableColumnFlags.WidthFixed, col2Width);
                 ImGui.TableSetupColumn("Mission Name", ImGuiTableColumnFlags.WidthFixed, maxMissionNameWidth);
@@ -977,6 +982,8 @@ namespace ICE.Ui
 
                     var mission = C.Missions.Single(x => x.Id == entry.Key);
                     var isEnabled = mission.Enabled;
+
+                    Utils.missionLength = Math.Max(Utils.missionLength, ImGui.CalcTextSize(mission.Name).X);
 
                     // Column 0: Enable checkbox
                     ImGui.TableSetColumnIndex(0);
@@ -1184,30 +1191,31 @@ namespace ICE.Ui
                         // debug
                         ImGui.TableNextColumn();
                         bool hasPreviousNotes = false;
+                        string notes = "";
                         if (entry.Value.Weather != CosmicWeather.FairSkies)
                         {
                             hasPreviousNotes = true;
-
-                            ImGui.TextWrapped(entry.Value.Weather.ToString());
+                            notes = entry.Value.Weather.ToString();
                         }
                         else if (entry.Value.Time != 0)
                         {
                             hasPreviousNotes = true;
-
-                            ImGui.TextWrapped($"{2 * (entry.Value.Time - 1)}:00 - {2 * (entry.Value.Time)}:00");
+                            notes = $"{2 * (entry.Value.Time - 1)}:00 - {2 * (entry.Value.Time)}:00";
                         }
                         else if (entry.Value.PreviousMissionID != 0)
                         {
                             hasPreviousNotes = true;
-
                             var (Id, Name) = MissionInfoDict.Where(m => m.Key == entry.Value.PreviousMissionID).Select(m => (Id: m.Key, Name: m.Value.Name)).FirstOrDefault();
-                            ImGui.TextWrapped($"[{Id}] {Name}");
+                            notes = $"[{Id}] {Name}";
                         }
                         if (entry.Value.JobId2 != 0)
                         {
                             if (hasPreviousNotes) ImGui.SameLine();
-                            ImGui.TextWrapped($"{jobOptions.Find(job => job.Id == entry.Value.JobId).Name}/{jobOptions.Find(job => job.Id == entry.Value.JobId2).Name}");
+                            notes += $"{jobOptions.Find(job => job.Id == entry.Value.JobId).Name}/{jobOptions.Find(job => job.Id == entry.Value.JobId2).Name}";
                         }
+                        float NotesLength = Math.Max(Utils.missionLength, ImGui.CalcTextSize(notes).X);
+                        Utils.MissionNotesLength = NotesLength;
+                        ImGui.TextWrapped(notes);
                     }
                 }
 

--- a/ICE/Ui/MainWindowV2.cs
+++ b/ICE/Ui/MainWindowV2.cs
@@ -387,7 +387,7 @@ namespace ICE.Ui
             if (ImGui.BeginChild("###MissionList", new Vector2(0, childHeight), true))
             {
 
-                if (ImGui.Checkbox("Show Unsupported Missions", ref hideUnsupported))
+                if (ImGui.Checkbox("Hide Unsupported Missions", ref hideUnsupported))
                 {
                     C.HideUnsupportedMissions = hideUnsupported;
                     C.Save();

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -87,7 +87,7 @@ namespace ICE.Ui
 
             if (ImGuiEx.IconButton("\uf013##Config", "Open ICE"))
             {
-                P.mainWindow.IsOpen = true;
+                P.mainWindow2.IsOpen = true;
             }
             ImGui.SameLine();
 

--- a/ICE/Ui/SettingsWindow.cs
+++ b/ICE/Ui/SettingsWindow.cs
@@ -37,8 +37,8 @@ internal class SettingsWindow : Window
             ,("Gathering Config", GatherSettings, null, true)
             ,("Overlay", Overlay, null, true)
             ,("Misc", Misc, null, true)
-#if DEBUG
             ,("Gamble Wheel Settings", GambaWheel, null, true)
+#if DEBUG
             ,("Debug", Debug, null, true)
 #endif
         );
@@ -503,9 +503,9 @@ internal class SettingsWindow : Window
             C.GambaEnabled = gambaEnabled;
             C.Save();
         }
+        ImGuiEx.HelpMarker("To run this, make sure you have the gamble wheels shown at Orbitingway, and press start. It will full auto from there.");
         if (gambaEnabled)
         {
-            ImGui.SameLine();
             ImGui.SetNextItemWidth(150);
             if (ImGui.SliderInt("Gamba Delay", ref gambaDelay, 50, 2000))
             {

--- a/ICE/Ui/SettingsWindow.cs
+++ b/ICE/Ui/SettingsWindow.cs
@@ -407,7 +407,8 @@ internal class SettingsWindow : Window
             minGpLimit: 500,
             maxGpLimit: maxGp,
             entryName: entry.Name,
-            ActionInfo: "Increases the number of items obtained when gathering by 2",
+            ActionInfo: "Increases the number of items obtained when gathering by 2\n" +
+                        "Will only apply when the gathering node has full durability",
             onEnabledChange: newVal =>
             {
                 entry.Buffs.YieldII = newVal;
@@ -429,7 +430,8 @@ internal class SettingsWindow : Window
             minGpLimit: 400,
             maxGpLimit: maxGp,
             entryName: entry.Name,
-            ActionInfo: "Increases the number of items obtained when gathering by 1",
+            ActionInfo: "Increases the number of items obtained when gathering by 1\n" +
+                        "Will only apply when the gathering node has full durability",
             onEnabledChange: newVal =>
             {
                 entry.Buffs.YieldI = newVal;

--- a/ICE/Utilities/GatheringUtil.cs
+++ b/ICE/Utilities/GatheringUtil.cs
@@ -1630,7 +1630,7 @@ public static unsafe class GatheringUtil
             ZoneId = 1237,
             NodeId = 35086,
             Position = new Vector3 (-635.22f, 73.97f, -704.67f),
-            LandZone = new Vector3 (-635.61f, 73.15f, -704.04f),
+            LandZone = new Vector3 (-636.22f, 73.17f, -703.98f),
             GatheringType = 2,
             NodeSet = 8
         },
@@ -1639,7 +1639,7 @@ public static unsafe class GatheringUtil
             ZoneId = 1237,
             NodeId = 35085,
             Position = new Vector3 (-621.59f, 75.08f, -715.89f),
-            LandZone = new Vector3 (-621.8f, 74.06f, -716.89f),
+            LandZone = new Vector3 (-620.05f, 74.21f, -717.71f),
             GatheringType = 2,
             NodeSet = 8
         },

--- a/ICE/Utilities/Kofi.cs
+++ b/ICE/Utilities/Kofi.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace ICE.Utilities;
 
-internal class Kofi
+internal class Kofi // Heavily borrowed from the Ecommons version. 
 {
     public static void DrawRight()
     {


### PR DESCRIPTION
-> Added a fix for Manual Gathering
-> Added some pathfinder settings on the gathering profile
  -> Simple: The original pathfinding option, will start at the first node and rotate it's way through
  -> Nearest: Will minimize distance and try to go to the nodes based on that
  -> Cyclic: Will try to optimize the distance between nodes for fastest time (very math nerdy)
 -> **Added a minimum GP setting**, will only start the mission when you're at X GP, otherwise will wait for it to regen before starting
 -> Added the ability to set the amount of gathered items for dual class missions to a higher multiplier (default is x1, if you want it to gather at minimum x2 you can now set it)
 -> Critical Mission 537 & 538 are now supported 