### PR TITLE
Gamba + Pandora fixes

### DIFF
--- a/ICE/Config.cs
+++ b/ICE/Config.cs
@@ -163,6 +163,7 @@ namespace ICE
         Orchestrion = 5,
         Housing = 6,
         Dye = 7,
-        Other = 8
+        Other = 8,
+        Materia = 9,
     }
 }

--- a/ICE/ICE.cs
+++ b/ICE/ICE.cs
@@ -85,6 +85,7 @@ public sealed partial class ICE : IDalamudPlugin
             settingWindow.IsOpen = true;
         };
         DictionaryCreation();
+        TaskGamba.EnsureGambaWeightsInitialized();
     }
 
     private static void Init()

--- a/ICE/Scheduler/Handlers/GenericManager.cs
+++ b/ICE/Scheduler/Handlers/GenericManager.cs
@@ -58,6 +58,9 @@ namespace ICE.Scheduler.Handlers
                     }
                 }
             }
+            if (EzThrottler.Throttle("DelayedTick"))
+                if (AddonHelper.IsAddonActive("WKSLottery") && C.GambaEnabled && SchedulerMain.State == IceState.Idle)
+                    SchedulerMain.EnablePlugin();
         }
     }
 }

--- a/ICE/Scheduler/Handlers/GenericManager.cs
+++ b/ICE/Scheduler/Handlers/GenericManager.cs
@@ -46,7 +46,7 @@ namespace ICE.Scheduler.Handlers
 
         internal static void Tick()
         {
-            if (SchedulerMain.State.HasFlag(IceState.Gather))
+            if (SchedulerMain.State.HasFlag(IceState.Gather) && !SchedulerMain.State.HasFlag(IceState.ManualMode))
             {
                 var featureEnabled = (P.Pandora.GetFeatureEnabled("Pandora Quick Gather") ?? false);
 

--- a/ICE/Scheduler/Tasks/TaskCrafting.cs
+++ b/ICE/Scheduler/Tasks/TaskCrafting.cs
@@ -73,6 +73,8 @@ namespace ICE.Scheduler.Tasks
                     var itemId = ExcelHelper.RecipeSheet.GetRow(main.Key).ItemResult.Value.RowId;
                     var subItem = ExcelHelper.RecipeSheet.GetRow(main.Key).Ingredient[0].Value.RowId; // need to directly reference this in the future
                     var mainNeed = main.Value;
+                    if (CosmicHelper.CurrentMissionInfo.Attributes.HasFlag(MissionAttributes.Gather) && CraftMultipleMissionItems == 1) // For Dual Class specifically, if we doing a mult - use it on first loop.
+                        mainNeed *= SchedulerMain.InitialGatheringItemMultiplier;
                     var subItemNeed = ExcelHelper.RecipeSheet.GetRow(main.Key).AmountIngredient[0].ToInt() * main.Value;
 
                     if (!PlayerHelper.GetItemCount((int)itemId, out var currentAmount))

--- a/ICE/Scheduler/Tasks/TaskGamba.cs
+++ b/ICE/Scheduler/Tasks/TaskGamba.cs
@@ -29,6 +29,18 @@ namespace ICE.Scheduler.Tasks
             new Gamba { ItemId = 48136, Weight = 0, Type = GambaType.Housing }, // Drafting Table
             new Gamba { ItemId = 6141,  Weight = 0, Type = GambaType.Other }, // Cordial HQ
             new Gamba { ItemId = 48158, Weight = 0, Type = GambaType.Other }, // Magicked Prism (Cosmic Exploration)
+            new Gamba { ItemId = 41762, Weight = 0, Type = GambaType.Materia }, // Gatherer's Guerdon Materia XI
+            new Gamba { ItemId = 41763, Weight = 0, Type = GambaType.Materia }, // Gatherer's Guile Materia XI
+            new Gamba { ItemId = 41764, Weight = 0, Type = GambaType.Materia }, // Gatherer's Grasp Materia XI
+            new Gamba { ItemId = 41765, Weight = 0, Type = GambaType.Materia }, // Craftsman's Competence Materia XI
+            new Gamba { ItemId = 41766, Weight = 0, Type = GambaType.Materia }, // Craftsman's Cunning Materia XI
+            new Gamba { ItemId = 41767, Weight = 0, Type = GambaType.Materia }, // Craftsman's Command Materia XI
+            new Gamba { ItemId = 41775, Weight = 0, Type = GambaType.Materia }, // Gatherer's Guerdon Materia XII
+            new Gamba { ItemId = 41776, Weight = 0, Type = GambaType.Materia }, // Gatherer's Guile Materia XII
+            new Gamba { ItemId = 41777, Weight = 0, Type = GambaType.Materia }, // Gatherer's Grasp Materia XII
+            new Gamba { ItemId = 41778, Weight = 0, Type = GambaType.Materia }, // Craftsman's Competence Materia XII
+            new Gamba { ItemId = 41779, Weight = 0, Type = GambaType.Materia }, // Craftsman's Cunning Materia XII
+            new Gamba { ItemId = 41780, Weight = 0, Type = GambaType.Materia }, // Craftsman's Command Materia XII
         };
 
         public static void EnsureGambaWeightsInitialized(bool force = false)


### PR DESCRIPTION
Makes Pandora only pause on non-manual missions.
Adds missing materia to gamba settings.
Makes sure gamba items are filled in on plugin start (Not just after talking to Scammingway or manually resetting).
Makes Gamba auto start if Gamba enabled once Lottery window shows up.