### PR TITLE
Fix: CriticalMission incorrectly set as TurnInGold/TurnInSilver via Quick Mission Apply

### DIFF
--- a/ICE/Ui/MainWindowV2.cs
+++ b/ICE/Ui/MainWindowV2.cs
@@ -1288,6 +1288,7 @@ namespace ICE.Ui
                     bool collectableMission = missionDict.Attributes.HasFlag(MissionAttributes.Collectables);
                     bool stellerReductionMission = missionDict.Attributes.HasFlag(MissionAttributes.ReducedItems);
                     bool TimedMission = missionDict.Attributes.HasFlag(MissionAttributes.ScoreTimeRemaining);
+                    bool CriticalMission = missionDict.Attributes.HasFlag(MissionAttributes.Critical); // is CriticalMission
 
                     bool dualclass = craftMission && (gatherMission || fishMission);
 
@@ -1299,7 +1300,15 @@ namespace ICE.Ui
                     // "Current Class", "All Missions", "Currently Enabled"
                     void UpdateMissions()
                     {
-                        if (TimedMission)
+                        if (CriticalMission)
+                        {
+                            // Exclude TurnInGold/TurnInSilver for CriticalMission
+                            mission.TurnInGold = false;
+                            mission.TurnInSilver = false;
+                            mission.TurnInASAP = selectedModes[2];
+                            mission.ManualMode = selectedModes[3];
+                        }
+                        else if (TimedMission)
                         {
                             if (!selectedModes[2] && !selectedModes[3])
                             {


### PR DESCRIPTION
Quick Mission Apply would incorrectly set CriticalMission to TurnInGold/TurnInSilver without any UI warning, causing item delivery to fail even with sufficient mission items.

<img width="1337" height="1069" alt="1" src="https://github.com/user-attachments/assets/775ce5f9-1a0b-4a40-9c52-5595b61228cb" />