### PR TITLE
Color XP bars differently if limit reached/bar capped (closes #132)

### DIFF
--- a/ICE/Ui/MainWindowV2.cs
+++ b/ICE/Ui/MainWindowV2.cs
@@ -1497,14 +1497,29 @@ namespace ICE.Ui
             if (filledWidth > 0f)
             {
                 var filledEnd = new Vector2(pos.X + filledWidth, pos.Y + size.Y);
+                var left = new Vector4(0.2f, 0.6f, 1f, 1f); // Blue #3399ff
+                var right = new Vector4(0.6f, 1f, 0.8f, 1f); // Green #99ffcc
+                if (currentXP > neededXP)
+                {
+                    if (currentXP >= maxXP)
+                    {
+                        left = new Vector4(1f, 0.84f, 0f, 1f); // Gold #ffd600
+                        right = new Vector4(1f, 0.84f, 0f, 1f); // Gold #ffd600
+                    }
+                    else
+                    {
+                        left = new Vector4(0.6f, 1f, 0.8f, 1f); // Green #99ffcc
+                        right = new Vector4(0.2f, 0.6f, 1f, 1f); // Blue #3399ff
+                    }
+                }
 
                 drawList.AddRectFilledMultiColor(
                     barStart,
                     filledEnd,
-                    ImGui.GetColorU32(new Vector4(0.2f, 0.6f, 1f, 1f)), // left
-                    ImGui.GetColorU32(new Vector4(0.6f, 1f, 0.8f, 1f)), // right
-                    ImGui.GetColorU32(new Vector4(0.6f, 1f, 0.8f, 1f)), // right
-                    ImGui.GetColorU32(new Vector4(0.2f, 0.6f, 1f, 1f))  // left
+                    ImGui.GetColorU32(left), // top-left
+                    ImGui.GetColorU32(right), // top-right
+                    ImGui.GetColorU32(right), // bottom-right
+                    ImGui.GetColorU32(left)  // bottom-left
                 );
             }
 


### PR DESCRIPTION
Currently it's very difficult to get any useful information from the XP bars past a certain point where the total amount of XP that a character has affects the last couple pixels:

<img width="207" height="236" alt="Image" src="https://github.com/user-attachments/assets/1cbe4b27-41a0-4b0a-ab45-7d37ffc076a9" />

My feature request in this case is to change the colour of the XP bar by flipping the colours when the bar is past the required level for the current tier, or turning it solid gold if a bar is capped (mocked up here for demonstration):

<img width="205" height="226" alt="image" src="https://github.com/user-attachments/assets/d63a95da-3874-4004-8b7d-c03d9c258592" />
