### PR TITLE
Add "ClearSkies" weather enum and fix related logic

### DIFF
--- a/ICE/Enums/Weather.cs
+++ b/ICE/Enums/Weather.cs
@@ -7,6 +7,7 @@
         UmbralWind, // WKSMissionUnit.Unknown7 13
         MoonDust,   // WKSMissionUnit.Unknown7 14
         Clouds,     // WKSMissionUnit.WKSMissionLotterySpecialCond.15
-        Rain        // WKSMissionUnit.WKSMissionLotterySpecialCond.16
+        Rain,       // WKSMissionUnit.WKSMissionLotterySpecialCond.16
+        ClearSkies  // 23
     }
 }

--- a/ICE/Utilities/Cosmic_Helper/CosmicHelper.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicHelper.cs
@@ -24,7 +24,7 @@ public static unsafe partial class CosmicHelper
     /// Currently contains all the WKSMissionLotterySpecialCond values that are weather based
     /// MAKE SURE. TO UPDATE THIS. COME NEW MOON
     /// </summary>
-    public static readonly HashSet<uint> WeatherSelection = new() { 13, 14, 15, 16 };
+    public static readonly HashSet<uint> WeatherSelection = new() { 13, 14, 15, 16, 23 };
 
     public static List<int> GreyIconList = new List<int>() { 91031, 91032, 91033, 91034, 91035, 91036, 91037, 91038, 91039, 91040, 91041 };
     public static Dictionary<CosmicWeather, int> WeatherIds = new()
@@ -33,6 +33,7 @@ public static unsafe partial class CosmicHelper
         [CosmicWeather.MoonDust] = 60222,
         [CosmicWeather.Clouds] = 60203,
         [CosmicWeather.Rain] = 60207,
+        [CosmicWeather.ClearSkies] = 60201,
     };
 
     public static readonly int MinimumLevel = 10;

--- a/ICE/Utilities/ICEDictornaryCreation.cs
+++ b/ICE/Utilities/ICEDictornaryCreation.cs
@@ -61,7 +61,10 @@ public sealed partial class ICE
             }
             else
             {
-                weather = (CosmicWeather)(timeAndWeather - 12);
+                if (timeAndWeather == 23)
+                    weather = CosmicWeather.ClearSkies;
+                else
+                    weather = (CosmicWeather)(timeAndWeather - 12);
                 // TODO: Go back and assign enums based on the value instead... or just directly give it a flag. Unsure. Feels dirty
             }
 


### PR DESCRIPTION
Fix missions that rely on the ClearSkies weather not working on the Oizys.
Tested only on the CN server since I don’t have the global client, but it should work the same there.