### PR TITLE
New option for whether to swap back to StartJob after each mission

### DIFF
--- a/ICE/Scheduler/Tasks/Task_TurninMission.cs
+++ b/ICE/Scheduler/Tasks/Task_TurninMission.cs
@@ -235,12 +235,18 @@ namespace ICE.Scheduler.Tasks
 
         public static bool? JobSwapCheck()
         {
-            if (Player.Job != Mission_Settings.StartJob && Mission_Settings.StartJob != 0)
+            if (Mission_Settings.ReturnToOriginalJob && Player.Job != Mission_Settings.StartJob && Mission_Settings.StartJob != 0)
             {
+                // Mission_Settings.ReturnToOriginalJob
                 if (EzThrottler.Throttle("Swapping to crafter job", 1000))
                     GearsetHandler.TaskClassChange((Job)Mission_Settings.StartJob);
 
                 return false;
+            }
+            else if (!Mission_Settings.ReturnToOriginalJob)
+            {
+                Mission_Settings.StartJob = Player.Job;
+                return true;
             }
             else
             {

--- a/ICE/Ui/MainUi/Settings/Settings_Table/Settings_TableColumns.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/Settings_TableColumns.cs
@@ -133,6 +133,7 @@ public static class Settings_TableColumns
         }
 
         ImGui.Checkbox("Stop after current mission", ref Mission_Settings.StopAfterCurrent);
+        ImGui.Checkbox("Return to original class after mission", ref Mission_Settings.ReturnToOriginalJob);
         bool relicTurnin = C.TurninRelic;
         if (ImGui.Checkbox($"Turnin if relic is complete##RelicTurnin_GeneralSetting", ref relicTurnin))
         {

--- a/ICE/Ui/MainUi/Settings/Settings_Table/StopWhen.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/StopWhen.cs
@@ -144,6 +144,8 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
             }
 
             #endregion
+
+            ImGui.Checkbox("Return to original class after mission", ref Mission_Settings.ReturnToOriginalJob);
         }
     }
 }

--- a/ICE/Utilities/Mission_Settings.cs
+++ b/ICE/Utilities/Mission_Settings.cs
@@ -6,6 +6,7 @@ namespace ICE.Utilities
     {
         // States that get set in the main Ui
         internal static bool StopAfterCurrent = false;
+        internal static bool ReturnToOriginalJob = true;
         internal static uint previouslyAbandoned = 0;
 
         // Gather Specifics


### PR DESCRIPTION
In the current codebase, this is the default behavior. (I also kept the default value as true so it doesn't break anything for people who rely on it for post-mission commands or whatever.) It doesn't break anything, but it looks sus to (for example) be on WVR, finish a mission, swap to CRP, and then immediately swap back to WVR to do the same mission again.

I made a point to set StartJob to the current class when invoking this behavior. At a quick glance, it looked necessary because StartJob is used to navigate per-class mission menus? Regardless, it works great in local testing, so hopefully this is how you would have done it anyway!

Added the new menu option to the inline Mission Settings and the Stop When... settings. I didn't think it made sense to add it to the overlay, but lmk if you'd like it changed and I'll update the PR.