### PR TITLE
Overlay improvements, gathering QoL, and pathing behavior options

### DIFF
--- a/ICE/ConfigFiles/Config_Gather.cs
+++ b/ICE/ConfigFiles/Config_Gather.cs
@@ -12,12 +12,12 @@ public partial class Config
     public bool UseOnFisher { get; set; } = false;
     public bool PreventOvercap { get; set; } = false;
     public bool UseOnlyInMission { get; set; } = false;
-    public int CordialMinRank { get; set; } = 6; // 0=all, 1=D+, 2=C+, 3=B+, 4=A+, 5=Ex+, 6=Ex+ only
+    public int CordialMinRank { get; set; } = 0; // 0=all, 1=D+, 2=C+, 3=B+, 4=A+, 5=Ex+, 6=Ex+ only
 
     public int SelectedGatherIndex { get; set; } = 0;
     public bool UseGatheringFood { get; set; } = false;
     public uint GatheringFood { get; set; } = 0;
-    public int FoodMinRank { get; set; } = 6; // 0=all, 1=D+, 2=C+, 3=B+, 4=A+, 5=Ex+, 6=Ex+ only
+    public int FoodMinRank { get; set; } = 0; // 0=all, 1=D+, 2=C+, 3=B+, 4=A+, 5=Ex+, 6=Ex+ only
 
     public List<GatherProfile> GatherSettings { get; set; } = new()
     {

--- a/ICE/ConfigFiles/Config_Gather.cs
+++ b/ICE/ConfigFiles/Config_Gather.cs
@@ -12,10 +12,12 @@ public partial class Config
     public bool UseOnFisher { get; set; } = false;
     public bool PreventOvercap { get; set; } = false;
     public bool UseOnlyInMission { get; set; } = false;
+    public int CordialMinRank { get; set; } = 6; // 0=all, 1=D+, 2=C+, 3=B+, 4=A+, 5=Ex+, 6=Ex+ only
 
     public int SelectedGatherIndex { get; set; } = 0;
     public bool UseGatheringFood { get; set; } = false;
     public uint GatheringFood { get; set; } = 0;
+    public int FoodMinRank { get; set; } = 6; // 0=all, 1=D+, 2=C+, 3=B+, 4=A+, 5=Ex+, 6=Ex+ only
 
     public List<GatherProfile> GatherSettings { get; set; } = new()
     {

--- a/ICE/ConfigFiles/Config_Misc.cs
+++ b/ICE/ConfigFiles/Config_Misc.cs
@@ -21,7 +21,7 @@ public partial class Config
     public bool PersonalReturnSpot { get; set; } = false;
     public bool ClosestNodeSelection { get; set; } = false;
     public bool RandomizeWaypoints { get; set; } = false;
-    public float RandomizeWaypointsRadius { get; set; } = 1.5f;
+    public float RandomizeWaypointsRadius { get; set; } = 1.0f;
     public bool RandomizeWaypointsDebug { get; set; } = false;
     public Dictionary<uint, Vector3> CrafterLocations { get; set; } = new();
     public List<MissionCommand> PostMissionCommands { get; set; } = new();

--- a/ICE/ConfigFiles/Config_Misc.cs
+++ b/ICE/ConfigFiles/Config_Misc.cs
@@ -22,6 +22,7 @@ public partial class Config
     public bool ClosestNodeSelection { get; set; } = false;
     public bool RandomizeWaypoints { get; set; } = false;
     public float RandomizeWaypointsRadius { get; set; } = 1.5f;
+    public bool RandomizeWaypointsDebug { get; set; } = false;
     public Dictionary<uint, Vector3> CrafterLocations { get; set; } = new();
     public List<MissionCommand> PostMissionCommands { get; set; } = new();
 

--- a/ICE/ConfigFiles/Config_Misc.cs
+++ b/ICE/ConfigFiles/Config_Misc.cs
@@ -19,6 +19,9 @@ public partial class Config
     public bool ShowSPM { get; set; } = false;
     public bool StartUponEnterMoon { get; set; } = false;
     public bool PersonalReturnSpot { get; set; } = false;
+    public bool ClosestNodeSelection { get; set; } = false;
+    public bool RandomizeWaypoints { get; set; } = false;
+    public float RandomizeWaypointsRadius { get; set; } = 1.5f;
     public Dictionary<uint, Vector3> CrafterLocations { get; set; } = new();
     public List<MissionCommand> PostMissionCommands { get; set; } = new();
 

--- a/ICE/ConfigFiles/Config_Overlay.cs
+++ b/ICE/ConfigFiles/Config_Overlay.cs
@@ -11,6 +11,7 @@ public partial class Config
     public bool ShowCurrentScore { get; set; } = true;
     public bool ShowTotalScore { get; set; } = true;
     public bool ShowExpBars { get; set; } = true;
+    public bool ShowExpBars_HideWhenMaxed { get; set; } = false;
     public bool Overlay_AutoResize { get; set; } = true;
     public bool Overlay_FilterByJob { get; set; } = false;
     public bool Overlay_AllMoons { get; set; } = true;

--- a/ICE/ConfigFiles/Config_Overlay.cs
+++ b/ICE/ConfigFiles/Config_Overlay.cs
@@ -14,4 +14,5 @@ public partial class Config
     public bool Overlay_AutoResize { get; set; } = true;
     public bool Overlay_FilterByJob { get; set; } = false;
     public bool Overlay_AllMoons { get; set; } = true;
+    public bool Overlay_HighlightTokenWeather { get; set; } = true;
 }

--- a/ICE/ConfigFiles/Config_Overlay.cs
+++ b/ICE/ConfigFiles/Config_Overlay.cs
@@ -14,6 +14,5 @@ public partial class Config
     public bool ShowExpBars_HideWhenMaxed { get; set; } = false;
     public bool Overlay_AutoResize { get; set; } = true;
     public bool Overlay_FilterByJob { get; set; } = false;
-    public bool Overlay_AllMoons { get; set; } = true;
     public bool Overlay_HighlightTokenWeather { get; set; } = true;
 }

--- a/ICE/ConfigFiles/Config_Overlay.cs
+++ b/ICE/ConfigFiles/Config_Overlay.cs
@@ -13,4 +13,5 @@ public partial class Config
     public bool ShowExpBars { get; set; } = true;
     public bool Overlay_AutoResize { get; set; } = true;
     public bool Overlay_FilterByJob { get; set; } = false;
+    public bool Overlay_AllMoons { get; set; } = true;
 }

--- a/ICE/ConfigFiles/Config_Overlay.cs
+++ b/ICE/ConfigFiles/Config_Overlay.cs
@@ -12,4 +12,5 @@ public partial class Config
     public bool ShowTotalScore { get; set; } = true;
     public bool ShowExpBars { get; set; } = true;
     public bool Overlay_AutoResize { get; set; } = true;
+    public bool Overlay_FilterByJob { get; set; } = false;
 }

--- a/ICE/ConfigFiles/Config_Overlay.cs
+++ b/ICE/ConfigFiles/Config_Overlay.cs
@@ -15,4 +15,6 @@ public partial class Config
     public bool Overlay_AutoResize { get; set; } = true;
     public bool Overlay_FilterByJob { get; set; } = false;
     public bool Overlay_HighlightTokenWeather { get; set; } = true;
+    public bool Overlay_UseCogsIcon { get; set; } = false;
+    public bool Overlay_RelicXpExpanded { get; set; } = false;
 }

--- a/ICE/ConfigFiles/Config_Safety.cs
+++ b/ICE/ConfigFiles/Config_Safety.cs
@@ -14,5 +14,7 @@ public partial class Config
     public int DelayCraftIncrease { get; set; } = 2500;
     public bool AnimationLockAbandon { get; set; } = true;
     public bool JumpIfStuck { get; set; } = false;
+    public bool RetargetIfStuck { get; set; } = false;
+    public int StuckDelayMs { get; set; } = 1000;
     public int DelayPostRelic { get; set; } = 0;
 }

--- a/ICE/ICE.cs
+++ b/ICE/ICE.cs
@@ -144,7 +144,11 @@ public sealed partial class ICE : IDalamudPlugin
     private void OnDraw()
     {
         if (PlayerHelper.IsInCosmicZone())
+        {
+            if (C.RandomizeWaypointsDebug)
+                Task_NavmeshMove.DrawRandomizationDebug();
             PictoManager.DrawPicto();
+        }
     }
 
     public void Dispose()

--- a/ICE/Scheduler/SchedulerMain.cs
+++ b/ICE/Scheduler/SchedulerMain.cs
@@ -40,7 +40,7 @@ namespace ICE.Scheduler
 
         internal static void Tick()
         {
-            if (!P.TaskManager.IsBusy && State != Idle)
+            if (P.TaskManager.NumQueuedTasks == 0 && State != Idle)
             {
                 switch (State)
                 {

--- a/ICE/Scheduler/Tasks/Task_CheckMissions.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckMissions.cs
@@ -675,6 +675,17 @@ namespace ICE.Scheduler.Tasks
         private static void Insert_GrabMissionTask(uint missionId)
         {
             P.TaskManager.Tasks.Clear();
+
+            // Extract materia between missions if spiritbond is ready and next mission is not EX+
+            if (C.SelfSpiritbondGather && Task_Spiritbond.IsSpiritbondReadyAny())
+            {
+                if (CosmicHelper.SheetMissionDict.TryGetValue(missionId, out var nextMission) && nextMission.Rank < 6)
+                {
+                    IceLogging.Info($"Next mission rank {nextMission.Rank} is below EX+, extracting materia first");
+                    P.TaskManager.Enqueue(() => Task_Spiritbond.ExtractMateria(), "Extracting materia before next mission");
+                }
+            }
+
             P.TaskManager.EnqueueMulti
                 (
                     new(() => CheckForMovementRequired(missionId), "Checking to see if we need to move to mission"),

--- a/ICE/Scheduler/Tasks/Task_Gather.cs
+++ b/ICE/Scheduler/Tasks/Task_Gather.cs
@@ -698,6 +698,13 @@ namespace ICE.Scheduler.Tasks
 
             return false;
         }
+        private static int GetCurrentMissionRank()
+        {
+            if (CosmicHelper.CurrentLunarMission != 0
+                && CosmicHelper.SheetMissionDict.TryGetValue(CosmicHelper.CurrentLunarMission, out var info))
+                return (int)info.Rank;
+            return 0;
+        }
         public static unsafe void UseCordial()
         {
             if (EzThrottler.Throttle("Cordial usage check while moving"))
@@ -707,6 +714,11 @@ namespace ICE.Scheduler.Tasks
                     IceLogging.Debug("Cordial Checkers");
                     if (C.AutoCordial)
                     {
+                        if (C.CordialMinRank > 0 && GetCurrentMissionRank() < C.CordialMinRank)
+                        {
+                            IceLogging.Debug($"Skipping cordial: mission rank {GetCurrentMissionRank()} below threshold {C.CordialMinRank}");
+                            return;
+                        }
                         IceLogging.Debug($"Min GP: {C.CordialMinGp} <= {PlayerHelper.GetGp()}");
 
                         if (PlayerHelper.GetGp() <= C.CordialMinGp)
@@ -755,6 +767,11 @@ namespace ICE.Scheduler.Tasks
             var ItemId = C.GatheringFood;
             if (C.UseGatheringFood && ItemId != 0)
             {
+                if (C.FoodMinRank > 0 && GetCurrentMissionRank() < C.FoodMinRank)
+                {
+                    IceLogging.Debug($"Skipping food: mission rank {GetCurrentMissionRank()} below threshold {C.FoodMinRank}");
+                    return true;
+                }
                 PlayerHelper.GetItemCount(ItemId, out var HqCount, includeNq: false);
                 PlayerHelper.GetItemCount(ItemId, out var NqCount, includeHq: false);
 

--- a/ICE/Scheduler/Tasks/Task_Gather.cs
+++ b/ICE/Scheduler/Tasks/Task_Gather.cs
@@ -4,6 +4,7 @@ using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using ICE.Utilities.Cosmic_Helper;
+using ICE.Resources.GatheringRoutes;
 using ICE.Utilities.GatheringHelper;
 using System.Collections.Generic;
 using static ECommons.UIHelpers.AddonMasterImplementations.AddonMaster;
@@ -268,8 +269,12 @@ namespace ICE.Scheduler.Tasks
                     var closestDistance = gatherInfo.Where(x => Player.DistanceTo(x.Position) < 5).FirstOrDefault();
                     if (closestDistance == null)
                     {
-                        // We're currently to far from any node. going to rely on the index to tell us where we should be
-                        if (Mission_Settings.nodeCounter >= gatherInfo.Count)
+                        // We're currently too far from any node
+                        if (C.ClosestNodeSelection)
+                        {
+                            SetClosestTargetableNode(gatherInfo);
+                        }
+                        else if (Mission_Settings.nodeCounter >= gatherInfo.Count)
                         {
                             // resetting it back to 0 because we're outside the normal index array
                             Mission_Settings.nodeCounter = 0;
@@ -295,13 +300,20 @@ namespace ICE.Scheduler.Tasks
                         }
                         else
                         {
-                            // Node is not targetable, increment to next node
-                            Mission_Settings.nodeCounter++;
-
-                            // Check if we're out of bounds and wrap back to 0
-                            if (Mission_Settings.nodeCounter >= gatherInfo.Count)
+                            if (C.ClosestNodeSelection)
                             {
-                                Mission_Settings.nodeCounter = 0;
+                                SetClosestTargetableNode(gatherInfo);
+                            }
+                            else
+                            {
+                                // Node is not targetable, increment to next node
+                                Mission_Settings.nodeCounter++;
+
+                                // Check if we're out of bounds and wrap back to 0
+                                if (Mission_Settings.nodeCounter >= gatherInfo.Count)
+                                {
+                                    Mission_Settings.nodeCounter = 0;
+                                }
                             }
                             return true;
                         }
@@ -311,6 +323,39 @@ namespace ICE.Scheduler.Tasks
 
             return false;
         }
+        private static void SetClosestTargetableNode(List<GathNodeInfo> gatherInfo)
+        {
+            var closestIndex = gatherInfo.Select((node, index) => new { Node = node, Index = index })
+                                         .Where(x => Svc.Objects.Any(obj => obj.ObjectKind == ObjectKind.GatheringPoint && obj.IsTargetable && obj.BaseId == x.Node.NodeId))
+                                         .OrderBy(x =>
+                                         {
+                                             var gameObject = Svc.Objects.First(obj => obj.BaseId == x.Node.NodeId && obj.IsTargetable);
+                                             return Player.DistanceTo(gameObject.Position);
+                                         })
+                                         .Select(x => x.Index)
+                                         .FirstOrDefault(-1);
+
+            if (closestIndex >= 0)
+                Mission_Settings.nodeCounter = closestIndex;
+            else
+            {
+                // No targetable nodes loaded in object table - fall back to closest route position,
+                // but exclude nodes we know are depleted (in object table but not targetable)
+                var fallbackIndex = gatherInfo.Select((node, index) => new { Node = node, Index = index })
+                                              .Where(x =>
+                                              {
+                                                  var obj = Svc.Objects.FirstOrDefault(o => o.ObjectKind == ObjectKind.GatheringPoint && o.BaseId == x.Node.NodeId);
+                                                  return obj == null || obj.IsTargetable;
+                                              })
+                                              .OrderBy(x => Player.DistanceTo(x.Node.Position))
+                                              .Select(x => x.Index)
+                                              .FirstOrDefault(-1);
+
+                Mission_Settings.nodeCounter = fallbackIndex >= 0 ? fallbackIndex : 0;
+            }
+        }
+        private const float SmartRoutingThreshold = 50f;
+
         public static bool? PathandCheckNode()
         {
             var zoneId = Player.Territory;
@@ -319,6 +364,15 @@ namespace ICE.Scheduler.Tasks
             var gatherInfo = GatheringRouteLoader.GetRoute(zoneId.RowId, missionFlag);
 
             var location = gatherInfo[Mission_Settings.nodeCounter];
+
+            // Use smart routing (aethernet/hub) for far nodes when closest node selection is active
+            if (C.ClosestNodeSelection && Player.DistanceTo(location.LandZone) > SmartRoutingThreshold)
+            {
+                IceLogging.Info($"Node is far ({Player.DistanceTo(location.LandZone):N0}y), using smart routing", "[Gathering: SmartRoute]");
+                Task_NavmeshMove.Enqueue_NavmeshTask(location.LandZone, distance: 1);
+                return true;
+            }
+
             if (!Task_NavmeshMove.Task_NavTo(location.LandZone, distance: 1).Value)
             {
                 UseCordial();

--- a/ICE/Scheduler/Tasks/Task_Gather.cs
+++ b/ICE/Scheduler/Tasks/Task_Gather.cs
@@ -217,7 +217,7 @@ namespace ICE.Scheduler.Tasks
                 _lastCollectProgress = DateTime.MinValue;
 
                 // if we've gotten this far, that means we're in a state that we should just be collecting
-                if (CanUseCollectableAction("BonusIntegrityChance", missingDur))
+                if (integrity < collectable.TotalIntegrity && CanUseCollectableAction("BonusIntegrityChance", missingDur))
                 {
                     if (EzThrottler.Throttle("Integrity bonus"))
                         UseCollectableAction("BonusIntegrityChance");

--- a/ICE/Scheduler/Tasks/Task_Gather.cs
+++ b/ICE/Scheduler/Tasks/Task_Gather.cs
@@ -13,6 +13,8 @@ namespace ICE.Scheduler.Tasks
 {
     internal static class Task_Gather
     {
+        private static int _lastCollectability = -1;
+        private static DateTime _lastCollectProgress = DateTime.MinValue;
 
         public static void Enqueue()
         {
@@ -152,7 +154,16 @@ namespace ICE.Scheduler.Tasks
             var playerGp = PlayerHelper.GetGp();
             bool missingDur = integrity < collectable.TotalIntegrity;
 
-            if (integrity > 1 && collect_Current < collect_highGrade)
+            // Track collectability progress to detect stuck rotations
+            if (collect_Current != _lastCollectability)
+            {
+                _lastCollectability = collect_Current;
+                _lastCollectProgress = DateTime.Now;
+            }
+            bool isStuck = _lastCollectProgress != DateTime.MinValue
+                        && (DateTime.Now - _lastCollectProgress).TotalSeconds > 5;
+
+            if (integrity > 1 && collect_Current < collect_highGrade && !isStuck)
             {
                 // this is the rotation we should be aiming for in general...
                 // this should cover all baselines
@@ -197,6 +208,13 @@ namespace ICE.Scheduler.Tasks
             }
             else
             {
+                if (isStuck)
+                    IceLogging.Debug("Collectable rotation stuck, falling through to collect");
+
+                // Reset progress tracking when we start collecting
+                _lastCollectability = -1;
+                _lastCollectProgress = DateTime.MinValue;
+
                 // if we've gotten this far, that means we're in a state that we should just be collecting
                 if (CanUseCollectableAction("BonusIntegrityChance", missingDur))
                 {

--- a/ICE/Scheduler/Tasks/Task_Gather.cs
+++ b/ICE/Scheduler/Tasks/Task_Gather.cs
@@ -682,7 +682,7 @@ namespace ICE.Scheduler.Tasks
 
             return false;
         }
-        public static bool? WaitForDesynthCompletion()
+        public static unsafe bool? WaitForDesynthCompletion()
         {
             if (!Svc.Condition[ConditionFlag.Occupied39])
             {
@@ -691,6 +691,18 @@ namespace ICE.Scheduler.Tasks
                 {
                     // Still have some more items to desynth, going to reset the current task count and re-check
                     P.TaskManager.Tasks.Clear();
+                }
+                else
+                {
+                    // All items reduced — close the aetherial reduction window before moving on
+                    try
+                    {
+                        if (GenericHelpers.TryGetAddonByName<AtkUnitBase>("PurifyItemSelector", out var desynthWindow) && desynthWindow->IsReady)
+                        {
+                            desynthWindow->Close(true);
+                        }
+                    }
+                    catch { }
                 }
 
                 return true;

--- a/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
+++ b/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
@@ -14,7 +14,7 @@ namespace ICE.Scheduler.Tasks
         private static readonly Random _random = new();
         private const float navmeshTolerance = 0.25f;
         private const float distanceToBeStuck = 1.0f;
-        private const int stuckTimeThresholdMs = 1000;
+        private static int stuckTimeThresholdMs => C.StuckDelayMs;
         private const int navmeshThrottleMs = 3000;
         private const int waitingThrottleMs = 1000;
         private const int positionLogThrottleMs = 500;
@@ -243,10 +243,18 @@ namespace ICE.Scheduler.Tasks
                 IceLogging.Verbose($"Current Pos: {currentPos:N2} | Last position: {lastPosition:N2} | Distance: {distanceMoved:N2}");
             }
 
-            // If stuck for long enough, try jumping
-            if (C.JumpIfStuck && timeSinceLastChecked >= stuckTimeThresholdMs && navmeshStartTime >= stuckTimeThresholdMs)
+            // If stuck for long enough, try unstuck actions
+            if (timeSinceLastChecked >= stuckTimeThresholdMs && navmeshStartTime >= stuckTimeThresholdMs)
             {
-                if (EzThrottler.Throttle("Using jump action"))
+                if (C.RetargetIfStuck && EzThrottler.Throttle("Retarget if stuck", 1000))
+                {
+                    IceLogging.Debug("Stuck detected - stopping navmesh to trigger retarget");
+                    P.Navmesh.Stop();
+                    ResetInfo();
+                    return;
+                }
+
+                if (C.JumpIfStuck && EzThrottler.Throttle("Using jump action"))
                 {
                     isJumpInProgress = true;
                     ActionManager.Instance()->UseAction(ActionType.GeneralAction, 2);

--- a/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
+++ b/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
@@ -11,6 +11,7 @@ namespace ICE.Scheduler.Tasks
     internal class Task_NavmeshMove
     {
         // Constants
+        private static readonly Random _random = new();
         private const float navmeshTolerance = 0.25f;
         private const float distanceToBeStuck = 1.0f;
         private const int stuckTimeThresholdMs = 1000;
@@ -171,7 +172,17 @@ namespace ICE.Scheduler.Tasks
                 ResetInfo();
                 IceLogging.DestinationLogs.Log(pos);
                 P.Navmesh.SetTolerance(navmeshTolerance);
-                P.Navmesh.PathfindAndMoveTo(pos, false);
+
+                var targetPos = pos;
+                if (C.RandomizeWaypoints)
+                {
+                    float radius = Math.Min(C.RandomizeWaypointsRadius, distance * 0.75f);
+                    float angle = (float)(_random.NextDouble() * 2 * Math.PI);
+                    float dist = (float)(Math.Sqrt(_random.NextDouble()) * radius);
+                    targetPos = new Vector3(pos.X + dist * MathF.Cos(angle), pos.Y, pos.Z + dist * MathF.Sin(angle));
+                }
+
+                P.Navmesh.PathfindAndMoveTo(targetPos, false);
             }
 
             return false;

--- a/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
+++ b/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
@@ -244,7 +244,7 @@ namespace ICE.Scheduler.Tasks
             }
 
             // If stuck for long enough, try jumping
-            if (timeSinceLastChecked >= stuckTimeThresholdMs && navmeshStartTime >= stuckTimeThresholdMs)
+            if (C.JumpIfStuck && timeSinceLastChecked >= stuckTimeThresholdMs && navmeshStartTime >= stuckTimeThresholdMs)
             {
                 if (EzThrottler.Throttle("Using jump action"))
                 {

--- a/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
+++ b/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
@@ -304,8 +304,8 @@ namespace ICE.Scheduler.Tasks
                 {
                     MapSelector = 0,
                     AethernetId = 2015057,
-                    Location = new(336.15f, 52.64f, -381.78f),
-                    LandZone = new(337.29f, 52.64f, -382.62f),
+                    Location = new(336.26f, 52.64f, -381.73f),
+                    LandZone = new(337.50f, 52.64f, -383.00f),
                 },
                 new()
                 {

--- a/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
+++ b/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
@@ -176,10 +176,18 @@ namespace ICE.Scheduler.Tasks
                 var targetPos = pos;
                 if (C.RandomizeWaypoints)
                 {
-                    float radius = Math.Min(C.RandomizeWaypointsRadius, distance * 0.75f);
-                    float angle = (float)(_random.NextDouble() * 2 * Math.PI);
-                    float dist = (float)(Math.Sqrt(_random.NextDouble()) * radius);
-                    targetPos = new Vector3(pos.X + dist * MathF.Cos(angle), pos.Y, pos.Z + dist * MathF.Sin(angle));
+                    var playerPos = Player.Position;
+                    var toTarget = pos - playerPos;
+                    var toTargetLen = new Vector2(toTarget.X, toTarget.Z).Length();
+                    if (toTargetLen > 0.1f)
+                    {
+                        float radius = C.RandomizeWaypointsRadius;
+                        float angle = (float)(_random.NextDouble() * 2 * Math.PI);
+                        float dist = (float)(Math.Pow(_random.NextDouble(), 0.33) * radius);
+                        targetPos = new Vector3(pos.X + dist * MathF.Cos(angle), pos.Y, pos.Z + dist * MathF.Sin(angle));
+
+                        SetRandomizationDebug(pos, targetPos, 0, radius);
+                    }
                 }
 
                 P.Navmesh.PathfindAndMoveTo(targetPos, false);
@@ -825,6 +833,38 @@ namespace ICE.Scheduler.Tasks
         private static async Task<List<Vector3>> FindPath(Vector3 position, Vector3 destination)
         {
             return await P.Navmesh.Pathfind(position, destination, false);
+        }
+
+        // Randomization debug visualization - stored so it can be drawn every frame
+        private static (Vector3 Original, Vector3 Randomized, float BackAngle, float Radius)? _randomDebug;
+
+        private static void SetRandomizationDebug(Vector3 originalPos, Vector3 randomizedPos, float backAngle, float radius)
+        {
+            _randomDebug = (originalPos, randomizedPos, backAngle, radius);
+        }
+
+        public static void ClearRandomizationDebug()
+        {
+            _randomDebug = null;
+        }
+
+        public static void DrawRandomizationDebug()
+        {
+            if (_randomDebug is not { } dbg) return;
+
+            uint circleColor = 0x4000FF00;    // green, 25% alpha
+            uint originalColor = 0xFFFFFFFF;  // white
+            uint randomizedColor = 0xFF00FF00; // green
+
+            // Draw circle showing the valid randomization zone
+            Handlers.PictoManager.AddDrawCommand(d => d.AddCircleFilled(dbg.Original, dbg.Radius, circleColor, circleColor));
+
+            // Draw original target (white circle)
+            Handlers.PictoManager.AddDrawCommand(d => d.AddCircleFilled(dbg.Original, 0.15f, originalColor, originalColor));
+            // Draw randomized target (green circle)
+            Handlers.PictoManager.AddDrawCommand(d => d.AddCircleFilled(dbg.Randomized, 0.15f, randomizedColor, randomizedColor));
+            // Line between them
+            Handlers.PictoManager.AddDrawCommand(d => d.AddLine(dbg.Original, dbg.Randomized, 0.01f, randomizedColor));
         }
     }
 }

--- a/ICE/Ui/MainUi/SelectableSidebar.cs
+++ b/ICE/Ui/MainUi/SelectableSidebar.cs
@@ -205,7 +205,7 @@ namespace ICE.Ui.MainUi
                 ImGui.Dummy(new Vector2(0, 10));
             }
         }
-        private static void AutoSelectMoonUpdate(bool autoSelectMoon)
+        public static void AutoSelectMoonUpdate(bool autoSelectMoon)
         {
             bool NeedsUpdate(bool sinus, bool phaenna, bool oizys)
             {
@@ -232,7 +232,7 @@ namespace ICE.Ui.MainUi
                     SetMoonVisibility(sinus: false, phaenna: false, oizys: true);
             }
         }
-        private static void AutoSelectClass(bool autoSelectClass)
+        public static void AutoSelectClass(bool autoSelectClass)
         {
             var jobId = (uint)Player.Job;
 

--- a/ICE/Ui/MainUi/SelectableSidebar.cs
+++ b/ICE/Ui/MainUi/SelectableSidebar.cs
@@ -37,34 +37,25 @@ namespace ICE.Ui.MainUi
                     // ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.Trophy, "Complete Overview", "modeSelect_Completion");
                     ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.ClipboardList, "Cosmic Agenda", "modeSelect_CosmicAgenda");
                 }
-                if (ImGui_Ice.Sidebar_CollaspableHeader("Settings", icon: FontAwesomeIcon.Cog))
-                {
-                    if (C.Show_StopWhen)
-                        ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.Stop, "Stop When...", "setting_StopWhen");
-                    if (C.Show_GatheringProfile)
-                        ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.Leaf, "Gathering Profile", "setting_GatheringProfile");
-                    if (C.Show_MissionPriority)
-                        ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.SortAmountUp, "Mission Priority", "setting_MissionPriority");
-                    if (C.Show_MiscSettings)
-                        ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.UserCog, "Misc Settings", "setting_Misc");
-
-                    ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.Cog, "All Settings", "helpSelect_AllSettings");
-                }
-                if (C.Show_HubActivities)
-                {
-                    if (ImGui_Ice.Sidebar_CollaspableHeader("Hub Activities", icon: FontAwesomeIcon.Home))
-                    {
-                        ImGui_Ice.DrawSelectable_Image(65112, "Credit Shopping", "hubActivities_CreditShopping");
-                        ImGui_Ice.DrawSelectable_Image(65127, "Gambling Settings", "hubActivites_GambaSetting");
-                        ImGui_Ice.DrawSelectable_Image(65138, "Dronebit Settings", "hubActivies_DroneSetting");
-                    }
-                }
                 if (ImGui_Ice.Sidebar_CollaspableHeader("Planet Selection", FontAwesomeIcon.Moon))
                 {
-                    if (ImGui_Ice.SliderButton("AutoSelectMoon", "Auto Select Moon", ref autoSelectMoon))
+                    if (ImGui_Ice.SliderButton("AutoSelectMoon", "Auto Select", ref autoSelectMoon))
                     {
                         C.AutoSelectMoon = autoSelectMoon;
                         C.Save();
+                    }
+                    ImGui.PushFont(UiBuilder.IconFont);
+                    var infoIconWidth = ImGui.CalcTextSize(FontAwesomeIcon.InfoCircle.ToIconString()).X;
+                    ImGui.PopFont();
+                    ImGui.SameLine(ImGui.GetContentRegionAvail().X + ImGui.GetCursorPosX() - infoIconWidth);
+                    ImGui.PushFont(UiBuilder.IconFont);
+                    ImGui.TextDisabled(FontAwesomeIcon.InfoCircle.ToIconString());
+                    ImGui.PopFont();
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.BeginTooltip();
+                        ImGui.Text("Filters which planets appear in the\nmission list and the overlay.");
+                        ImGui.EndTooltip();
                     }
                     ImGui.Dummy(new(0, 3));
 
@@ -102,7 +93,28 @@ namespace ICE.Ui.MainUi
                         }
                     }
                 }
+                if (ImGui_Ice.Sidebar_CollaspableHeader("Settings", icon: FontAwesomeIcon.Cog))
+                {
+                    if (C.Show_StopWhen)
+                        ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.Stop, "Stop When...", "setting_StopWhen");
+                    if (C.Show_GatheringProfile)
+                        ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.Leaf, "Gathering Profile", "setting_GatheringProfile");
+                    if (C.Show_MissionPriority)
+                        ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.SortAmountUp, "Mission Priority", "setting_MissionPriority");
+                    if (C.Show_MiscSettings)
+                        ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.UserCog, "Misc Settings", "setting_Misc");
 
+                    ImGui_Ice.DrawSelectable_Icon(FontAwesomeIcon.Cog, "All Settings", "helpSelect_AllSettings");
+                }
+                if (C.Show_HubActivities)
+                {
+                    if (ImGui_Ice.Sidebar_CollaspableHeader("Hub Activities", icon: FontAwesomeIcon.Home))
+                    {
+                        ImGui_Ice.DrawSelectable_Image(65112, "Credit Shopping", "hubActivities_CreditShopping");
+                        ImGui_Ice.DrawSelectable_Image(65127, "Gambling Settings", "hubActivites_GambaSetting");
+                        ImGui_Ice.DrawSelectable_Image(65138, "Dronebit Settings", "hubActivies_DroneSetting");
+                    }
+                }
                 var currentClass = C.SelectedJob;
                 var classIcon = ImGui_Ice.GetGreyscaleJob(currentClass);
                 if (ImGui_Ice.Sidebar_CollaspableHeader("Select Class", imageTexture: classIcon))

--- a/ICE/Ui/MainUi/Settings/Settings_Table/GatherSettings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/GatherSettings.cs
@@ -13,6 +13,7 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
     {
         private static string newProfileName = "";
         private static string[] MissionTypes = ["Limited Nodes", "Gather x Amount", "Time Attack", "Chained Scoring", "Boon Scoring", "Chain + Boon Scoring", "Dual Class"];
+        private static readonly string[] RankLabels = ["All Missions", "D and above", "C and above", "B and above", "A and above", "EX and above", "EX+ only"];
         private static int MissionIndex = 0;
 
         private static readonly string PROFILE_PREFIX = "IceGatherProfile_";
@@ -201,6 +202,14 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
                                "Will also pause pandora cordial usage while on the moon");
             if (ImGui.CollapsingHeader("Cordial Settings"))
             {
+                int cordialMinRank = C.CordialMinRank;
+                ImGui.SetNextItemWidth(150);
+                if (ImGui.Combo("Min mission rank for cordials", ref cordialMinRank, RankLabels, RankLabels.Length))
+                {
+                    C.CordialMinRank = cordialMinRank;
+                    C.Save();
+                }
+
                 bool InverseCordialPrio = C.inverseCordialPrio;
                 bool PreventOvercap = C.PreventOvercap;
                 int CordialMinGp = C.CordialMinGp;
@@ -228,6 +237,14 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
 
             if (ImGui.CollapsingHeader("Food Settings"))
             {
+                int foodMinRank = C.FoodMinRank;
+                ImGui.SetNextItemWidth(150);
+                if (ImGui.Combo("Min mission rank for food", ref foodMinRank, RankLabels, RankLabels.Length))
+                {
+                    C.FoodMinRank = foodMinRank;
+                    C.Save();
+                }
+
                 bool useFood = C.UseGatheringFood;
                 if (ImGui.Checkbox("Use food on gathering missions", ref useFood))
                 {

--- a/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
@@ -70,6 +70,13 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
                 C.ShowOverlay = showOverlay;
                 C.Save();
             }
+            ImGui.SameLine();
+            bool useCogsIcon = C.Overlay_UseCogsIcon;
+            if (ImGui.Checkbox("Use cogs button instead of home", ref useCogsIcon))
+            {
+                C.Overlay_UseCogsIcon = useCogsIcon;
+                C.Save();
+            }
 
             bool ShowSeconds = C.ShowSeconds;
             if (ImGui.Checkbox("Show Seconds", ref ShowSeconds))
@@ -101,7 +108,7 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
                 C.ShowCurrentScore = showClassScore;
                 C.Save();
             }
-
+            ImGui.SameLine();
             bool showTotalScore = C.ShowTotalScore;
             if (ImGui.Checkbox("Show Total Score", ref showTotalScore))
             {

--- a/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
@@ -360,6 +360,39 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
             }
             ImGui.Checkbox("Visualize Dismount Radius", ref visualizeDismountRadius);
 
+            ImGui.Dummy(new Vector2(0, 5));
+            bool closestNode = C.ClosestNodeSelection;
+            if (ImGui.Checkbox("Prioritize closest gathering node", ref closestNode))
+            {
+                C.ClosestNodeSelection = closestNode;
+                C.Save();
+            }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.SetTooltip("Always navigate to the closest targetable node instead of following the fixed route order.\nUseful for timed EX+ missions where speed matters.");
+            }
+
+            bool randomize = C.RandomizeWaypoints;
+            if (ImGui.Checkbox("Randomize waypoint positions", ref randomize))
+            {
+                C.RandomizeWaypoints = randomize;
+                C.Save();
+            }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.SetTooltip("Adds a small random offset to navigation destinations so the character doesn't always follow the exact same path");
+            }
+            if (randomize)
+            {
+                float radius = C.RandomizeWaypointsRadius;
+                ImGui.SetNextItemWidth(100);
+                if (ImGui.SliderFloat("Randomize radius (yalms)", ref radius, 0.5f, 5.0f, "%.1f"))
+                {
+                    C.RandomizeWaypointsRadius = radius;
+                    C.SaveDebounced();
+                }
+            }
+
             using (var drawList = PictoService.Draw(hints: Utils.GetPictoHints()))
             {
                 if (drawList == null)

--- a/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
@@ -116,12 +116,6 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
                 C.Save();
             }
 
-            bool allMoons = C.Overlay_AllMoons;
-            if (ImGui.Checkbox("Show all moons in weather/timed table", ref allMoons))
-            {
-                C.Overlay_AllMoons = allMoons;
-                C.Save();
-            }
 
             bool highlightTokenWeather = C.Overlay_HighlightTokenWeather;
             if (ImGui.Checkbox("Highlight EX+ token weathers", ref highlightTokenWeather))

--- a/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
@@ -102,10 +102,15 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
             bool AutoResize = C.Overlay_AutoResize;
             if (ImGui.Checkbox("Auto Resize Overlay", ref AutoResize))
             {
-
                 C.Overlay_AutoResize = AutoResize;
                 C.Save();
+            }
 
+            bool filterByJob = C.Overlay_FilterByJob;
+            if (ImGui.Checkbox("Filter timed missions by current job", ref filterByJob))
+            {
+                C.Overlay_FilterByJob = filterByJob;
+                C.Save();
             }
 
             bool disableHudClipping = C.DisableHudClipping;

--- a/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
@@ -59,7 +59,7 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
             Separator();
         }
 
-        private static void OverlaySettings()
+        public static void OverlaySettings()
         {
             ImGuiEx.IconWithText(FontAwesomeIcon.WindowMaximize, "Overlay Window");
             ImGui.Dummy(new (0, 5));

--- a/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
@@ -404,10 +404,16 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
             {
                 float radius = C.RandomizeWaypointsRadius;
                 ImGui.SetNextItemWidth(100);
-                if (ImGui.SliderFloat("Randomize radius (yalms)", ref radius, 0.5f, 5.0f, "%.1f"))
+                if (ImGui.SliderFloat("Randomize radius (yalms)", ref radius, 0.5f, 1.0f, "%.1f"))
                 {
                     C.RandomizeWaypointsRadius = radius;
                     C.SaveDebounced();
+                }
+                bool showDebug = C.RandomizeWaypointsDebug;
+                if (ImGui.Checkbox("Show random location debug target", ref showDebug))
+                {
+                    C.RandomizeWaypointsDebug = showDebug;
+                    C.Save();
                 }
             }
 

--- a/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
@@ -84,6 +84,16 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
                 C.ShowExpBars = showExpOverlay;
                 C.Save();
             }
+            if (showExpOverlay)
+            {
+                ImGui.SameLine();
+                bool hideWhenMaxed = C.ShowExpBars_HideWhenMaxed;
+                if (ImGui.Checkbox("Until maxed only", ref hideWhenMaxed))
+                {
+                    C.ShowExpBars_HideWhenMaxed = hideWhenMaxed;
+                    C.Save();
+                }
+            }
 
             bool showClassScore = C.ShowCurrentScore;
             if (ImGui.Checkbox("Show Current Class Score", ref showClassScore))

--- a/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
@@ -113,8 +113,15 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
                 C.Save();
             }
 
+            bool highlightTokenWeather = C.Overlay_HighlightTokenWeather;
+            if (ImGui.Checkbox("Highlight EX+ token weathers", ref highlightTokenWeather))
+            {
+                C.Overlay_HighlightTokenWeather = highlightTokenWeather;
+                C.Save();
+            }
+
             bool filterByJob = C.Overlay_FilterByJob;
-            if (ImGui.Checkbox("Filter timed missions by current job", ref filterByJob))
+            if (ImGui.Checkbox("Filter timed/weather missions and weather highlights by current job", ref filterByJob))
             {
                 C.Overlay_FilterByJob = filterByJob;
                 C.Save();

--- a/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/Misc_Settings.cs
@@ -106,6 +106,13 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
                 C.Save();
             }
 
+            bool allMoons = C.Overlay_AllMoons;
+            if (ImGui.Checkbox("Show all moons in weather/timed table", ref allMoons))
+            {
+                C.Overlay_AllMoons = allMoons;
+                C.Save();
+            }
+
             bool filterByJob = C.Overlay_FilterByJob;
             if (ImGui.Checkbox("Filter timed missions by current job", ref filterByJob))
             {

--- a/ICE/Ui/MainUi/Settings/Settings_Table/SafetySettings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/SafetySettings.cs
@@ -74,16 +74,38 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
                     }
                 }
             }
-            bool jumpIfStuck = C.JumpIfStuck;
-            if (ImGui.Checkbox("Jump if stuck during nav movement", ref jumpIfStuck))
+            ImGui.Text("If stuck during nav movement:");
+            ImGui.SameLine();
+            ImGuiEx.HelpMarker(
+                "When stuck during navmesh movement for the configured delay:\n" +
+                "- Jump: attempts to jump over the obstacle\n" +
+                "- Retarget: stops and re-pathfinds to the destination (re-randomizes if enabled)");
+            if (ImGui.RadioButton("Jump", C.JumpIfStuck && !C.RetargetIfStuck))
             {
-                C.JumpIfStuck = jumpIfStuck;
+                C.JumpIfStuck = true;
+                C.RetargetIfStuck = false;
                 C.Save();
             }
-            ImGuiEx.HelpMarker(
-                "If you get stuck while navmesh moving, this will allow you to jump after a certain time has passed (3s currently)\n" +
-                "NOTE: THIS IS EXPERIMENTAL. IT WORKS, BUT IT STILL LOOKS SUS. IF YOU SEE A POINT AND YOUR STUCK, REPORT IT PLEASE\n" +
-                "through the logs function, and give info about it so we can fix it.");
+            ImGui.SameLine();
+            if (ImGui.RadioButton("Retarget", C.RetargetIfStuck))
+            {
+                C.RetargetIfStuck = true;
+                C.JumpIfStuck = false;
+                C.Save();
+            }
+            ImGui.SameLine();
+            ImGui.Text("after");
+            ImGui.SameLine();
+            int stuckDelay = C.StuckDelayMs;
+            ImGui.SetNextItemWidth(100);
+            if (ImGui.SliderInt("ms stuck###StuckDelay", ref stuckDelay, 500, 3000))
+            {
+                if (C.StuckDelayMs != stuckDelay)
+                {
+                    C.StuckDelayMs = stuckDelay;
+                    C.SaveDebounced();
+                }
+            }
             ImGui.Dummy(Vector2.Zero);
 
             int delayRelic = C.DelayPostRelic;

--- a/ICE/Ui/MainUi/Settings/Settings_Table/SafetySettings.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_Table/SafetySettings.cs
@@ -74,12 +74,24 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
                     }
                 }
             }
-            ImGui.Text("If stuck during nav movement:");
+            bool unstuckEnabled = C.JumpIfStuck || C.RetargetIfStuck;
+            if (ImGui.Checkbox("If stuck during nav movement:", ref unstuckEnabled))
+            {
+                if (unstuckEnabled)
+                    C.JumpIfStuck = true;
+                else
+                {
+                    C.JumpIfStuck = false;
+                    C.RetargetIfStuck = false;
+                }
+                C.Save();
+            }
             ImGui.SameLine();
             ImGuiEx.HelpMarker(
                 "When stuck during navmesh movement for the configured delay:\n" +
                 "- Jump: attempts to jump over the obstacle\n" +
                 "- Retarget: stops and re-pathfinds to the destination (re-randomizes if enabled)");
+            if (!unstuckEnabled) ImGui.BeginDisabled();
             if (ImGui.RadioButton("Jump", C.JumpIfStuck && !C.RetargetIfStuck))
             {
                 C.JumpIfStuck = true;
@@ -106,6 +118,7 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
                     C.SaveDebounced();
                 }
             }
+            if (!unstuckEnabled) ImGui.EndDisabled();
             ImGui.Dummy(Vector2.Zero);
 
             int delayRelic = C.DelayPostRelic;

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -198,6 +198,8 @@ namespace ICE.Ui
                         ImGui.Text($"[{mission.Key}]");
                         ImGui.SameLine(0, 2);
                         ImGui.Text($"{mission.Value.Name}");
+                        var expires = EorzeaHoursUntil(eorzeaTime, (int)mission.Value.EndTime);
+                        ImGui.Text($"Expires in {FormatRealTime(expires)}");
                         ImGui.EndTooltip();
                     }
                 }
@@ -220,6 +222,8 @@ namespace ICE.Ui
                         ImGui.Text($"[{mission.Key}]");
                         ImGui.SameLine(0, 2);
                         ImGui.Text($"{mission.Value.Name}");
+                        var startsIn = EorzeaHoursUntil(eorzeaTime, (int)mission.Value.StartTime);
+                        ImGui.Text($"Starts in {FormatRealTime(startsIn)}");
                         ImGui.EndTooltip();
                     }
                 }
@@ -251,6 +255,22 @@ namespace ICE.Ui
                 ImGui.Text(icon == FontAwesomeIcon.Cloud ? "Weather" : "Timed");
                 ImGui.EndTooltip();
             }
+        }
+        private static double EorzeaHoursUntil(DateTimeOffset eorzeaTime, int targetHour)
+        {
+            double currentFractional = eorzeaTime.Hour + eorzeaTime.Minute / 60.0 + eorzeaTime.Second / 3600.0;
+            double hoursUntil = targetHour - currentFractional;
+            if (hoursUntil <= 0)
+                hoursUntil += 24;
+            return hoursUntil;
+        }
+        private static string FormatRealTime(double eorzeaHours)
+        {
+            // 1 Eorzea hour = 175 real seconds
+            int totalSeconds = (int)(eorzeaHours * 175);
+            int minutes = totalSeconds / 60;
+            int seconds = totalSeconds % 60;
+            return minutes > 0 ? $"{minutes}m {seconds:D2}s" : $"{seconds}s";
         }
         private bool IsAvailableAtHour(CosmicInfo mission, int hour)
         {

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -156,6 +156,15 @@ namespace ICE.Ui
                     ImGui.Separator();
                     foreach (var mission in weatherMissions[forecast.IconId])
                     {
+                        foreach (var jobId in mission.Value.Jobs)
+                        {
+                            if (CosmicHelper.JobIconDict.TryGetValue(jobId, out var jobIcon))
+                            {
+                                ImGui.Image(jobIcon.GetWrapOrEmpty().Handle, new Vector2(18, 18));
+                                ImGui.SameLine(0, 4);
+                            }
+                        }
+                        ImGui.AlignTextToFramePadding();
                         ImGui.Text($"[{mission.Key}] {mission.Value.Name} ({mission.Value.RewardItemAmount}x tokens)");
                     }
                 }

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -56,10 +56,25 @@ namespace ICE.Ui
 
                 ImGui.TableHeadersRow();
 
-                WeatherForcastForTerritory(1291, "ICE.Resources.Phaenna.png");
-                TimedMissionDetailsForTerritory(1291, "ICE.Resources.Phaenna.png");
-                WeatherForcastForTerritory(1310, "ICE.Resources.Oizys.png");
-                TimedMissionDetailsForTerritory(1310, "ICE.Resources.Oizys.png");
+                if (C.Overlay_AllMoons)
+                {
+                    WeatherForcastForTerritory(1291, "ICE.Resources.Phaenna.png");
+                    TimedMissionDetailsForTerritory(1291, "ICE.Resources.Phaenna.png");
+                    WeatherForcastForTerritory(1310, "ICE.Resources.Oizys.png");
+                    TimedMissionDetailsForTerritory(1310, "ICE.Resources.Oizys.png");
+                }
+                else
+                {
+                    var territory = Player.Territory.RowId;
+                    var moonAsset = territory == 1291 ? "ICE.Resources.Phaenna.png"
+                                  : territory == 1310 ? "ICE.Resources.Oizys.png"
+                                  : null;
+                    if (moonAsset != null)
+                    {
+                        WeatherForcastForTerritory((ushort)territory, moonAsset);
+                        TimedMissionDetailsForTerritory((ushort)territory, moonAsset);
+                    }
+                }
 
                 ImGui.EndTable();
             }
@@ -252,7 +267,7 @@ namespace ICE.Ui
         }
         private void HomeButtons()
         {
-            if (ImGuiEx.IconButton(FontAwesomeIcon.Home, "Open ICE"))
+            if (ImGuiEx.IconButton(FontAwesomeIcon.Cogs, "Open ICE"))
             {
                 P.mainWindow.IsOpen = true;
             }

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -8,6 +8,7 @@ using ICE.Utilities.ImGuiTools;
 using Lumina.Excel.Sheets;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Reflection;
 using TerraFX.Interop.Windows;
 using static ICE.Utilities.CosmicHelper;
 
@@ -38,6 +39,9 @@ namespace ICE.Ui
             Flags = C.Overlay_AutoResize
                 ? ImGuiWindowFlags.AlwaysAutoResize
                 : ImGuiWindowFlags.None;
+
+            if (C.Overlay_AutoResize)
+                ImGui.SetNextWindowSizeConstraints(Vector2.Zero, new Vector2(float.MaxValue, float.MaxValue));
         }
 
         public override void Draw()
@@ -52,16 +56,10 @@ namespace ICE.Ui
 
                 ImGui.TableHeadersRow();
 
-
-                if (true)
-                {
-                    WeatherForcast();
-                }
-
-                if (true)
-                {
-                    TimedMissionDetails();
-                }
+                WeatherForcastForTerritory(1291, "ICE.Resources.Phaenna.png");
+                TimedMissionDetailsForTerritory(1291, "ICE.Resources.Phaenna.png");
+                WeatherForcastForTerritory(1310, "ICE.Resources.Oizys.png");
+                TimedMissionDetailsForTerritory(1310, "ICE.Resources.Oizys.png");
 
                 ImGui.EndTable();
             }
@@ -92,16 +90,15 @@ namespace ICE.Ui
             }
 #endif
         }
-        private void WeatherForcast()
+        private void WeatherForcastForTerritory(ushort territoryId, string moonAsset)
         {
-            var weatherForecasts = WeatherForecastHandler.GetNextWeathers(6); // Current + next 4
+            var weatherForecasts = WeatherForecastHandler.GetTerritoryForecast(territoryId);
 
             if (weatherForecasts.Count == 0) return;
 
             ImGui.TableNextRow();
             ImGui.TableSetColumnIndex(0);
-            ImGui.AlignTextToFramePadding();
-            ImGui.Text("Weather");
+            DrawMoonAndIcon(moonAsset, FontAwesomeIcon.Cloud);
 
             // Current weather column
             ImGui.TableNextColumn();
@@ -137,34 +134,37 @@ namespace ICE.Ui
                     {
                         ImGui.BeginTooltip();
                         ImGui.Text($"{weather.Name}");
-                        ImGui.Text($"In: {weather.TimeUntil}");
+                        ImGui.Text($"In: {WeatherForecastHandler.FormatForecastTime(weather.Time)}");
                         ImGui.EndTooltip();
                     }
                 }
             }
         }
-        private unsafe void TimedMissionDetails()
+        private unsafe void TimedMissionDetailsForTerritory(uint territoryId, string moonAsset)
         {
             var eorzeaTime = DateTimeOffset.FromUnixTimeSeconds(Framework.Instance()->ClientTime.EorzeaTime);
             int currentHour = eorzeaTime.Hour;
             int nextHour = (currentHour + 1) % 24;
 
+            var jobFilter = C.Overlay_FilterByJob ? (uint?)Player.Job : null;
+
             var currentHourMissions = SheetMissionDict
                 .Where(kvp => IsAvailableAtHour(kvp.Value, currentHour))
-                .Where(kvp => kvp.Value.TerritoryId == Player.Territory.RowId)
+                .Where(kvp => kvp.Value.TerritoryId == territoryId)
+                .Where(kvp => jobFilter == null || kvp.Value.Jobs.Contains(jobFilter.Value))
                 .OrderBy(kvp => kvp.Value.Jobs.FirstOrDefault())
                 .ToList();
 
             var nextHourMissions = SheetMissionDict
                 .Where(kvp => IsAvailableAtHour(kvp.Value, nextHour))
-                .Where(kvp => kvp.Value.TerritoryId == Player.Territory.RowId)
+                .Where(kvp => kvp.Value.TerritoryId == territoryId)
+                .Where(kvp => jobFilter == null || kvp.Value.Jobs.Contains(jobFilter.Value))
                 .OrderBy(kvp => kvp.Value.Jobs.FirstOrDefault())
                 .ToList();
 
             ImGui.TableNextRow();
             ImGui.TableSetColumnIndex(0);
-            ImGui.AlignTextToFramePadding();
-            ImGui.Text("Timed");
+            DrawMoonAndIcon(moonAsset, FontAwesomeIcon.Clock);
 
             ImGui.TableNextColumn();
             for (int i = 0; i < currentHourMissions.Count; i++)
@@ -208,6 +208,33 @@ namespace ICE.Ui
                         ImGui.EndTooltip();
                     }
                 }
+            }
+        }
+        private static readonly Dictionary<string, string> MoonNames = new()
+        {
+            ["ICE.Resources.Phaenna.png"] = "Phaenna",
+            ["ICE.Resources.Oizys.png"] = "Oizys",
+        };
+        private void DrawMoonAndIcon(string moonAsset, FontAwesomeIcon icon)
+        {
+            var moonTexture = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), moonAsset).GetWrapOrEmpty();
+            ImGui.Image(moonTexture.Handle, new Vector2(23, 23));
+            if (ImGui.IsItemHovered() && MoonNames.TryGetValue(moonAsset, out var moonName))
+            {
+                ImGui.BeginTooltip();
+                ImGui.Text(moonName);
+                ImGui.EndTooltip();
+            }
+            ImGui.SameLine(0, 4);
+            ImGui.AlignTextToFramePadding();
+            ImGui.PushFont(UiBuilder.IconFont);
+            ImGui.Text(icon.ToIconString());
+            ImGui.PopFont();
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.Text(icon == FontAwesomeIcon.Cloud ? "Weather" : "Timed");
+                ImGui.EndTooltip();
             }
         }
         private bool IsAvailableAtHour(CosmicInfo mission, int hour)

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -56,23 +56,12 @@ namespace ICE.Ui
 
                 ImGui.TableHeadersRow();
 
-                if (C.Overlay_AllMoons)
+                foreach (var planet in Planets)
                 {
-                    WeatherForcastForTerritory(1291, "ICE.Resources.Phaenna.png");
-                    TimedMissionDetailsForTerritory(1291, "ICE.Resources.Phaenna.png");
-                    WeatherForcastForTerritory(1310, "ICE.Resources.Oizys.png");
-                    TimedMissionDetailsForTerritory(1310, "ICE.Resources.Oizys.png");
-                }
-                else
-                {
-                    var territory = Player.Territory.RowId;
-                    var moonAsset = territory == 1291 ? "ICE.Resources.Phaenna.png"
-                                  : territory == 1310 ? "ICE.Resources.Oizys.png"
-                                  : null;
-                    if (moonAsset != null)
+                    if (planet.IsEnabled())
                     {
-                        WeatherForcastForTerritory((ushort)territory, moonAsset);
-                        TimedMissionDetailsForTerritory((ushort)territory, moonAsset);
+                        WeatherForcastForTerritory((ushort)planet.TerritoryId, planet.Asset);
+                        TimedMissionDetailsForTerritory(planet.TerritoryId, planet.Asset);
                     }
                 }
 
@@ -372,16 +361,18 @@ namespace ICE.Ui
                 }
             }
         }
-        private static readonly Dictionary<string, string> MoonNames = new()
+        private static readonly (uint TerritoryId, string Asset, string Name, Func<bool> IsEnabled)[] Planets = new[]
         {
-            ["ICE.Resources.Phaenna.png"] = "Phaenna",
-            ["ICE.Resources.Oizys.png"] = "Oizys",
+            ((uint)1237, "ICE.Resources.Sinus_Ardorum.png", "Sinus Ardorum", new Func<bool>(() => C.ShowSinusMissions)),
+            ((uint)1291, "ICE.Resources.Phaenna.png", "Phaenna", new Func<bool>(() => C.ShowPhaennaMissions)),
+            ((uint)1310, "ICE.Resources.Oizys.png", "Oizys", new Func<bool>(() => C.ShowOizysMissions)),
         };
         private void DrawMoonAndIcon(string moonAsset, FontAwesomeIcon icon)
         {
             var moonTexture = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), moonAsset).GetWrapOrEmpty();
             ImGui.Image(moonTexture.Handle, new Vector2(23, 23));
-            if (ImGui.IsItemHovered() && MoonNames.TryGetValue(moonAsset, out var moonName))
+            var moonName = Planets.FirstOrDefault(p => p.Asset == moonAsset).Name;
+            if (ImGui.IsItemHovered() && moonName != null)
             {
                 ImGui.BeginTooltip();
                 ImGui.Text(moonName);

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -468,7 +468,20 @@ namespace ICE.Ui
         }
         private void ClassRelicDetails()
         {
-            if (C.ShowExpBars)
+            if (!C.ShowExpBars) return;
+
+            if (C.ShowExpBars_HideWhenMaxed)
+            {
+                var expInfo = CosmicHelper.Cosmic_ClassInfo();
+                var currentJobId = (uint)Player.Job;
+                if (expInfo.TryGetValue(currentJobId, out var jobInfo)
+                    && jobInfo.CurrentExp.Count > 0
+                    && jobInfo.CurrentExp.Values.All(exp => exp.Current >= exp.Needed))
+                {
+                    return;
+                }
+            }
+
             {
                 var currentJobId = (uint)Player.Job;
                 if (ImGui.CollapsingHeader("Relic Tool XP"))

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -86,16 +86,112 @@ namespace ICE.Ui
             ClassRelicDetails();
         }
 
+        internal static void DrawModeSelectPopup(string popupId)
+        {
+            if (ImGui.BeginPopup(popupId))
+            {
+                ImGui.Text("Select Mode");
+                ImGui.Separator();
+
+                bool standard = C.SelectedMode == ModeSelect.Standard;
+                bool relicMode = C.SelectedMode == ModeSelect.RelicMode;
+                bool xpLeveling = C.SelectedMode == ModeSelect.LevelMode;
+                bool agendaMode = C.SelectedMode == ModeSelect.AgendaMode;
+
+                if (ImGui.RadioButton("Standard", standard))
+                {
+                    C.SelectedMode = ModeSelect.Standard;
+                    C.Save();
+                }
+                if (ImGui.RadioButton("Relic Grind", relicMode))
+                {
+                    C.SelectedMode = ModeSelect.RelicMode;
+                    C.Save();
+                }
+                if (ImGui.RadioButton("Leveling Grind", xpLeveling))
+                {
+                    C.SelectedMode = ModeSelect.LevelMode;
+                    C.Save();
+                }
+                if (ImGui.RadioButton("Agenda Mode", agendaMode))
+                {
+                    C.SelectedMode = ModeSelect.AgendaMode;
+                    C.Save();
+                }
+
+                ImGui.EndPopup();
+            }
+        }
         private void MissionDetails()
         {
-            ImGui.Text($"Current state: " + SchedulerMain.State.ToString());
+            if (ImGuiEx.IconButton(FontAwesomeIcon.ListUl, "##OverlayModeSelect"))
+            {
+                ImGui.OpenPopup("Overlay Mode Select");
+            }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.Text("Change mode");
+                ImGui.EndTooltip();
+            }
+            DrawModeSelectPopup("Overlay Mode Select");
+            ImGui.SameLine();
+            var modeName = C.SelectedMode switch
+            {
+                ModeSelect.Standard => "Standard",
+                ModeSelect.RelicMode => "Relic Grind",
+                ModeSelect.LevelMode => "Leveling Grind",
+                ModeSelect.AgendaMode => "Cosmic Agenda",
+                _ => C.SelectedMode.ToString(),
+            };
+            ImGui.Text($"{modeName} - {SchedulerMain.State}");
+
+            // Start/Stop toggle
+            bool running = SchedulerMain.State != IceState.Idle;
+            if (running)
+                ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.2f, 0.6f, 0.2f, 1.0f));
+            if (ImGuiEx.IconButton(running ? FontAwesomeIcon.Stop : FontAwesomeIcon.Play, "##StartStop"))
+            {
+                if (running)
+                    SchedulerMain.DisablePlugin();
+                else
+                    SchedulerMain.EnablePlugin();
+            }
+            if (running)
+                ImGui.PopStyleColor();
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.Text(running ? "Stop" : "Start");
+                ImGui.EndTooltip();
+            }
+
+            // Stop after current mission toggle
+            ImGui.SameLine();
+            bool stopAfter = Mission_Settings.StopAfterCurrent;
+            if (stopAfter)
+                ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.8f, 0.5f, 0.0f, 1.0f));
+            if (ImGuiEx.IconButton(FontAwesomeIcon.StepForward, "##StopAfterCurrent"))
+            {
+                Mission_Settings.StopAfterCurrent = !Mission_Settings.StopAfterCurrent;
+            }
+            if (stopAfter)
+                ImGui.PopStyleColor();
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.Text(Mission_Settings.StopAfterCurrent ? "Stop after current mission: ON" : "Stop after current mission: OFF");
+                ImGui.EndTooltip();
+            }
+
+            ImGui.SameLine();
             if (CosmicHelper.SheetMissionDict.TryGetValue(CosmicHelper.CurrentLunarMission, out var missionName) && SchedulerMain.State != IceState.AbandonMission)
             {
-                ImGui.TextWrapped($"Current Mission: [{CosmicHelper.CurrentLunarMission}] {missionName.Name}");
+                ImGui.TextWrapped($"[{CosmicHelper.CurrentLunarMission}] {missionName.Name}");
             }
             else
             {
-                ImGui.Text("Current Mission: None");
+                ImGui.Text("No mission");
             }
 #if DEBUG
             if (C.ShowDebugGatherInfo)
@@ -338,39 +434,6 @@ namespace ICE.Ui
             {
                 P.mainWindow.IsOpen = true;
             }
-            ImGui.SameLine();
-
-            // Start button (disabled while already ticking).
-            bool xpLeveling = C.SelectedMode == ModeSelect.LevelMode;
-            bool unsupportedArtisan = xpLeveling && !P.Artisan.UpdatedArtisan() && CosmicHelper.CrafterJobList.Contains((uint)Player.Job);
-            bool unsupportedClass = !PlayerHelper.UsingSupportedJob();
-
-            bool unsupported = SchedulerMain.State != IceState.Idle || !PlayerHelper.UsingSupportedJob() || unsupportedArtisan;
-
-            using (ImRaii.Disabled(unsupported))
-            {
-                var defaultButtonColor = ImGui.GetStyle().Colors[(int)ImGuiCol.Button];
-                var color = unsupported ? EColor.Red : defaultButtonColor;
-
-                using var tempButton = ImRaii.PushColor(ImGuiCol.Button, color);
-                if (ImGui.Button("Start"))
-                {
-                    SchedulerMain.EnablePlugin();
-                }
-            }
-
-            ImGui.SameLine();
-
-            // Stop button (disabled while not ticking).
-            using (ImRaii.Disabled(SchedulerMain.State == IceState.Idle))
-            {
-                if (ImGui.Button("Stop"))
-                {
-                    SchedulerMain.DisablePlugin();
-                }
-            }
-            ImGui.SameLine();
-            ImGui.Checkbox("Stop after current mission", ref Mission_Settings.StopAfterCurrent);
 
             // Drone finder toggle
             ImGui.SameLine();

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -4,6 +4,7 @@ using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
+using ICE.Ui.MainUi;
 using ICE.Utilities.ImGuiTools;
 using Lumina.Excel.Sheets;
 using System.Collections.Generic;
@@ -49,11 +50,15 @@ namespace ICE.Ui
 
         public override void Draw()
         {
+            SelectableSidebar.AutoSelectClass(C.AutoPickCurrentJob);
+            SelectableSidebar.AutoSelectMoonUpdate(C.AutoSelectMoon);
+
             MissionDetails();
 
-            if (ImGui.BeginTable("Weather/Time Info", 3, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.Borders))
+            if (ImGui.BeginTable("Weather/Time Info", 4, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.Borders))
             {
-                ImGui.TableSetupColumn("");
+                ImGui.TableSetupColumn("##Planets");
+                ImGui.TableSetupColumn("##Icons");
                 ImGui.TableSetupColumn("Current");
                 ImGui.TableSetupColumn("Next");
 
@@ -417,7 +422,7 @@ namespace ICE.Ui
                 ImGui.Text(moonName);
                 ImGui.EndTooltip();
             }
-            ImGui.SameLine(0, 4);
+            ImGui.TableNextColumn();
             ImGui.AlignTextToFramePadding();
             ImGui.PushFont(UiBuilder.IconFont);
             ImGui.Text(icon.ToIconString());

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -115,7 +115,11 @@ namespace ICE.Ui
         private void MissionDetails()
         {
             var settingsIcon = C.Overlay_UseCogsIcon ? FontAwesomeIcon.Cogs : FontAwesomeIcon.Home;
-            if (ImGuiEx.IconButton(settingsIcon, "##OpenICE"))
+            ImGui.PushFont(UiBuilder.IconFont);
+            var iconWidth = ImGui.CalcTextSize(FontAwesomeIcon.Cogs.ToIconString()).X;
+            ImGui.PopFont();
+            var buttonSize = new Vector2(iconWidth + ImGui.GetStyle().FramePadding.X * 2, 0);
+            if (ImGuiEx.IconButton(settingsIcon, "##OpenICE", buttonSize))
             {
                 P.mainWindow.IsOpen = true;
             }
@@ -126,7 +130,7 @@ namespace ICE.Ui
                 ImGui.EndTooltip();
             }
             ImGui.SameLine();
-            if (ImGuiEx.IconButton(FontAwesomeIcon.ListUl, "##OverlayModeSelect"))
+            if (ImGuiEx.IconButton(FontAwesomeIcon.ListUl, "##OverlayModeSelect", buttonSize))
             {
                 ImGui.OpenPopup("Overlay Mode Select");
             }
@@ -143,7 +147,7 @@ namespace ICE.Ui
                 bool droneActive = SchedulerMain.State == IceState.ArtifactSearch;
                 if (droneActive)
                     ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.2f, 0.6f, 0.2f, 1.0f));
-                if (ImGuiEx.IconButton(FontAwesomeIcon.SearchLocation, "##DroneFinder"))
+                if (ImGuiEx.IconButton(FontAwesomeIcon.SearchLocation, "##DroneFinder", buttonSize))
                 {
                     if (droneActive)
                         SchedulerMain.DisablePlugin();
@@ -175,7 +179,7 @@ namespace ICE.Ui
             bool running = SchedulerMain.State != IceState.Idle;
             if (running)
                 ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.2f, 0.6f, 0.2f, 1.0f));
-            if (ImGuiEx.IconButton(running ? FontAwesomeIcon.Stop : FontAwesomeIcon.Play, "##StartStop"))
+            if (ImGuiEx.IconButton(running ? FontAwesomeIcon.Stop : FontAwesomeIcon.Play, "##StartStop", buttonSize))
             {
                 if (running)
                     SchedulerMain.DisablePlugin();
@@ -196,7 +200,7 @@ namespace ICE.Ui
             bool stopAfter = Mission_Settings.StopAfterCurrent;
             if (stopAfter)
                 ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.8f, 0.5f, 0.0f, 1.0f));
-            if (ImGuiEx.IconButton(FontAwesomeIcon.StepForward, "##StopAfterCurrent"))
+            if (ImGuiEx.IconButton(FontAwesomeIcon.StepForward, "##StopAfterCurrent", buttonSize))
             {
                 Mission_Settings.StopAfterCurrent = !Mission_Settings.StopAfterCurrent;
             }

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -5,6 +5,7 @@ using Dalamud.Interface.Utility.Raii;
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using ICE.Ui.MainUi;
+using ICE.Ui.MainUi.Settings.Settings_Table;
 using ICE.Utilities.ImGuiTools;
 using Lumina.Excel.Sheets;
 using System.Collections.Generic;
@@ -22,6 +23,14 @@ namespace ICE.Ui
             Flags = ImGuiWindowFlags.None;
      
             P.windowSystem.AddWindow(this);
+            TitleBarButtons.Add(
+                new()
+                {
+                    ShowTooltip = () => ImGui.SetTooltip("Overlay Settings"),
+                    Icon = FontAwesomeIcon.Cog,
+                    IconOffset = new(1, 1),
+                    Click = _ => ImGui.OpenPopup("OverlaySettingsPopup")
+                });
         }
 
         public void Dispose()
@@ -50,6 +59,12 @@ namespace ICE.Ui
 
         public override void Draw()
         {
+            if (ImGui.BeginPopup("OverlaySettingsPopup"))
+            {
+                Misc_Settings.OverlaySettings();
+                ImGui.EndPopup();
+            }
+
             SelectableSidebar.AutoSelectClass(C.AutoPickCurrentJob);
             SelectableSidebar.AutoSelectMoonUpdate(C.AutoSelectMoon);
 
@@ -580,5 +595,7 @@ namespace ICE.Ui
                 }
             }
         }
+
+
     }
 }

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -71,8 +71,6 @@ namespace ICE.Ui
                 ImGui.EndTable();
             }
 
-            HomeButtons();
-
             ClassExpDetails();
 
             ClassRelicDetails();
@@ -116,6 +114,17 @@ namespace ICE.Ui
         }
         private void MissionDetails()
         {
+            if (ImGuiEx.IconButton(FontAwesomeIcon.Cogs, "##OpenICE"))
+            {
+                P.mainWindow.IsOpen = true;
+            }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.Text("Open ICE");
+                ImGui.EndTooltip();
+            }
+            ImGui.SameLine();
             if (ImGuiEx.IconButton(FontAwesomeIcon.ListUl, "##OverlayModeSelect"))
             {
                 ImGui.OpenPopup("Overlay Mode Select");
@@ -127,7 +136,30 @@ namespace ICE.Ui
                 ImGui.EndTooltip();
             }
             DrawModeSelectPopup("Overlay Mode Select");
+            if (PlayerHelper.IsInOizys())
+            {
+                ImGui.SameLine();
+                bool droneActive = SchedulerMain.State == IceState.ArtifactSearch;
+                if (droneActive)
+                    ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.2f, 0.6f, 0.2f, 1.0f));
+                if (ImGuiEx.IconButton(FontAwesomeIcon.SearchLocation, "##DroneFinder"))
+                {
+                    if (droneActive)
+                        SchedulerMain.DisablePlugin();
+                    else
+                        SchedulerMain.State = IceState.ArtifactSearch;
+                }
+                if (droneActive)
+                    ImGui.PopStyleColor();
+                if (ImGui.IsItemHovered())
+                {
+                    ImGui.BeginTooltip();
+                    ImGui.Text(droneActive ? "Stop Drone Finder" : "Run Drone Finder");
+                    ImGui.EndTooltip();
+                }
+            }
             ImGui.SameLine();
+
             var modeName = C.SelectedMode switch
             {
                 ModeSelect.Standard => "Standard",
@@ -423,35 +455,6 @@ namespace ICE.Ui
             else
             {
                 return hour >= mission.StartTime || hour < mission.EndTime;
-            }
-        }
-        private void HomeButtons()
-        {
-            if (ImGuiEx.IconButton(FontAwesomeIcon.Cogs, "Open ICE"))
-            {
-                P.mainWindow.IsOpen = true;
-            }
-
-            // Drone finder toggle (only on Oizys)
-            if (!PlayerHelper.IsInOizys()) return;
-            ImGui.SameLine();
-            bool droneActive = SchedulerMain.State == IceState.ArtifactSearch;
-            if (droneActive)
-                ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.2f, 0.6f, 0.2f, 1.0f));
-            if (ImGuiEx.IconButton(FontAwesomeIcon.SearchLocation, "##DroneFinder"))
-            {
-                if (droneActive)
-                    SchedulerMain.DisablePlugin();
-                else
-                    SchedulerMain.State = IceState.ArtifactSearch;
-            }
-            if (droneActive)
-                ImGui.PopStyleColor();
-            if (ImGui.IsItemHovered())
-            {
-                ImGui.BeginTooltip();
-                ImGui.Text(droneActive ? "Stop Drone Finder" : "Run Drone Finder");
-                ImGui.EndTooltip();
             }
         }
         private void ClassExpDetails()

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -105,11 +105,72 @@ namespace ICE.Ui
             }
 #endif
         }
+        private static Dictionary<uint, List<KeyValuePair<uint, CosmicInfo>>> GetExPlusTokenWeatherMissions(uint territoryId)
+        {
+            var jobFilter = C.Overlay_FilterByJob ? (uint?)Player.Job : null;
+            var result = new Dictionary<uint, List<KeyValuePair<uint, CosmicInfo>>>();
+            foreach (var kvp in SheetMissionDict)
+            {
+                var mission = kvp.Value;
+                if (mission.TerritoryId == territoryId
+                    && mission.Rank >= 6
+                    && mission.Weather != CosmicWeather.None
+                    && mission.RewardItem != 0
+                    && (jobFilter == null || mission.Jobs.Contains(jobFilter.Value))
+                    && CosmicHelper.WeatherIds.TryGetValue(mission.Weather, out var iconId))
+                {
+                    var key = (uint)iconId;
+                    if (!result.ContainsKey(key))
+                        result[key] = new List<KeyValuePair<uint, CosmicInfo>>();
+                    result[key].Add(kvp);
+                }
+            }
+            return result;
+        }
+        private void DrawWeatherIcon(WeatherForecast forecast, Dictionary<uint, List<KeyValuePair<uint, CosmicInfo>>> weatherMissions, string extraTooltip = null)
+        {
+            if (!Svc.Texture.TryGetFromGameIcon(forecast.IconId, out var weatherIcon))
+                return;
+
+            var iconSize = new Vector2(23, 23);
+            bool highlight = weatherMissions.ContainsKey(forecast.IconId);
+
+            if (highlight)
+            {
+                var drawList = ImGui.GetWindowDrawList();
+                var pos = ImGui.GetCursorScreenPos();
+                var center = pos + iconSize * 0.5f;
+                drawList.AddCircle(center, 13, ImGui.GetColorU32(new Vector4(1.0f, 0.85f, 0.0f, 1.0f)), 0, 2.0f);
+            }
+
+            ImGui.Image(weatherIcon.GetWrapOrEmpty().Handle, iconSize);
+
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.Text($"{forecast.Name}");
+                if (extraTooltip != null)
+                    ImGui.Text(extraTooltip);
+                if (highlight)
+                {
+                    ImGui.Separator();
+                    foreach (var mission in weatherMissions[forecast.IconId])
+                    {
+                        ImGui.Text($"[{mission.Key}] {mission.Value.Name} ({mission.Value.RewardItemAmount}x tokens)");
+                    }
+                }
+                ImGui.EndTooltip();
+            }
+        }
         private void WeatherForcastForTerritory(ushort territoryId, string moonAsset)
         {
             var weatherForecasts = WeatherForecastHandler.GetTerritoryForecast(territoryId);
 
             if (weatherForecasts.Count == 0) return;
+
+            var weatherMissions = C.Overlay_HighlightTokenWeather
+                ? GetExPlusTokenWeatherMissions(territoryId)
+                : new Dictionary<uint, List<KeyValuePair<uint, CosmicInfo>>>();
 
             ImGui.TableNextRow();
             ImGui.TableSetColumnIndex(0);
@@ -119,18 +180,7 @@ namespace ICE.Ui
             ImGui.TableNextColumn();
             if (weatherForecasts.Count > 0)
             {
-                var current = weatherForecasts[0];
-                if (Svc.Texture.TryGetFromGameIcon(current.IconId, out var weatherIcon))
-                {
-                    ImGui.Image(weatherIcon.GetWrapOrEmpty().Handle, new Vector2(23, 23));
-
-                    if (ImGui.IsItemHovered())
-                    {
-                        ImGui.BeginTooltip();
-                        ImGui.Text($"{current.Name}");
-                        ImGui.EndTooltip();
-                    }
-                }
+                DrawWeatherIcon(weatherForecasts[0], weatherMissions);
             }
 
             // Next weather column - show next 4 weathers
@@ -140,19 +190,7 @@ namespace ICE.Ui
                 if (i > 1)
                     ImGui.SameLine(0, 2);
 
-                var weather = weatherForecasts[i];
-                if (Svc.Texture.TryGetFromGameIcon(weather.IconId, out var weatherIcon))
-                {
-                    ImGui.Image(weatherIcon.GetWrapOrEmpty().Handle, new Vector2(23, 23));
-
-                    if (ImGui.IsItemHovered())
-                    {
-                        ImGui.BeginTooltip();
-                        ImGui.Text($"{weather.Name}");
-                        ImGui.Text($"In: {WeatherForecastHandler.FormatForecastTime(weather.Time)}");
-                        ImGui.EndTooltip();
-                    }
-                }
+                DrawWeatherIcon(weatherForecasts[i], weatherMissions, $"In: {WeatherForecastHandler.FormatForecastTime(weatherForecasts[i].Time)}");
             }
         }
         private unsafe void TimedMissionDetailsForTerritory(uint territoryId, string moonAsset)

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -289,6 +289,27 @@ namespace ICE.Ui
             }
             ImGui.SameLine();
             ImGui.Checkbox("Stop after current mission", ref Mission_Settings.StopAfterCurrent);
+
+            // Drone finder toggle
+            ImGui.SameLine();
+            bool droneActive = SchedulerMain.State == IceState.ArtifactSearch;
+            if (droneActive)
+                ImGui.PushStyleColor(ImGuiCol.Button, new Vector4(0.2f, 0.6f, 0.2f, 1.0f));
+            if (ImGuiEx.IconButton(FontAwesomeIcon.SearchLocation, "##DroneFinder"))
+            {
+                if (droneActive)
+                    SchedulerMain.DisablePlugin();
+                else
+                    SchedulerMain.State = IceState.ArtifactSearch;
+            }
+            if (droneActive)
+                ImGui.PopStyleColor();
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.Text(droneActive ? "Stop Drone Finder" : "Run Drone Finder");
+                ImGui.EndTooltip();
+            }
         }
         private void ClassExpDetails()
         {

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -41,7 +41,10 @@ namespace ICE.Ui
                 : ImGuiWindowFlags.None;
 
             if (C.Overlay_AutoResize)
-                ImGui.SetNextWindowSizeConstraints(Vector2.Zero, new Vector2(float.MaxValue, float.MaxValue));
+            {
+                var minWidth = ImGui.CalcTextSize(new string('A', 30)).X + ImGui.GetStyle().WindowPadding.X * 2;
+                ImGui.SetNextWindowSizeConstraints(new Vector2(minWidth, 0), new Vector2(float.MaxValue, float.MaxValue));
+            }
         }
 
         public override void Draw()
@@ -176,7 +179,10 @@ namespace ICE.Ui
             ImGui.SameLine();
             if (CosmicHelper.SheetMissionDict.TryGetValue(CosmicHelper.CurrentLunarMission, out var missionName) && SchedulerMain.State != IceState.AbandonMission)
             {
-                ImGui.TextWrapped($"[{CosmicHelper.CurrentLunarMission}] {missionName.Name}");
+                var missionText = $"[{CosmicHelper.CurrentLunarMission}] {missionName.Name}";
+                if (missionText.Length > 35)
+                    missionText = missionText[..32] + "...";
+                ImGui.Text(missionText);
             }
             else
             {
@@ -426,7 +432,8 @@ namespace ICE.Ui
                 P.mainWindow.IsOpen = true;
             }
 
-            // Drone finder toggle
+            // Drone finder toggle (only on Oizys)
+            if (!PlayerHelper.IsInOizys()) return;
             ImGui.SameLine();
             bool droneActive = SchedulerMain.State == IceState.ArtifactSearch;
             if (droneActive)

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -114,7 +114,8 @@ namespace ICE.Ui
         }
         private void MissionDetails()
         {
-            if (ImGuiEx.IconButton(FontAwesomeIcon.Cogs, "##OpenICE"))
+            var settingsIcon = C.Overlay_UseCogsIcon ? FontAwesomeIcon.Cogs : FontAwesomeIcon.Home;
+            if (ImGuiEx.IconButton(settingsIcon, "##OpenICE"))
             {
                 P.mainWindow.IsOpen = true;
             }
@@ -557,7 +558,14 @@ namespace ICE.Ui
 
             {
                 var currentJobId = (uint)Player.Job;
-                if (ImGui.CollapsingHeader("Relic Tool XP"))
+                var flags = C.Overlay_RelicXpExpanded ? ImGuiTreeNodeFlags.DefaultOpen : ImGuiTreeNodeFlags.None;
+                var open = ImGui.CollapsingHeader("Relic Tool XP", flags);
+                if (open != C.Overlay_RelicXpExpanded)
+                {
+                    C.Overlay_RelicXpExpanded = open;
+                    C.Save();
+                }
+                if (open)
                 {
                     ImGui_Ice.Draw_ExpTable(currentJobId);
                 }


### PR DESCRIPTION
Big fan of the plugin. These are some QoL improvements and bug fixes I ran into while using it - all tested in game.

<img width="294" height="277" alt="image" src="https://github.com/user-attachments/assets/5b4fcfbb-e57a-4b06-a9ff-34a254ce7db7" />

- Cross-moon weather/timed overlay - weather forecasts and timed missions for both Phaenna and Oizys with moon planet icons and cloud/clock icons, with expiry/start countdown on hover. Option to show all moons or current only.
- Consumable rank thresholds - separate minimum rank settings for cordial and food (default EX+ only) to avoid wasting them on easy missions.
- Close aetherial reduction window - closes PurifyItemSelector after all reductions complete instead of leaving it open.
- Materia extraction between missions - extracts materia when spiritbond is ready and the next mission isn't EX+.
- Drone finder overlay toggle - icon button in the overlay to start/stop drone finder, turns green when active.
- Job filter for timed/weather missions - optional filter in settings to only show timed missions and weather highlights for the current job.
- Fix Phaenna hub aetheryte (Glassblower Beacon) coordinates - the hardcoded position was off by ~2 units, putting the landing zone at the edge of interaction range.
- Stuck collectible rotation detection - detects when the gathering rotation stops making progress and falls through to collect.
- Closest node selection - option to always navigate to the closest targetable gathering node instead of following the fixed route order, useful for timed EX+ missions. Uses smart routing (aethernet/hub) for far nodes and skips depleted nodes when finding fallback positions.
- Waypoint target randomization - option to add a small random offset to navigation destinations so the character doesn't always follow the exact same path, with configurable radius.
- Wise to the World safeguard - added an explicit integrity check to prevent Wise to the World from being used at max integrity during collectable gathering, a safeguard against something that actually happened to me.
- EX+ token weather highlights - weather icons in the overlay get a yellow circle when an EX+ mission with token rewards requires that weather, with job icons and mission details in the tooltip. Toggleable in overlay settings.
- Auto-hide relic XP bars - "Until maxed only" checkbox next to the experience bars option, automatically hides the bars when all exp types for the current job are at or over cap (useful when switching between maxed and non-maxed classes).
- Overlay controls - mode selector button, start/stop toggle (green when running), and stop-after-current-mission toggle (orange when active) directly in the overlay, replacing the old Start/Stop buttons and checkbox.

- Planet selection overlay integration - overlay weather/timed table now follows the planet selection filter instead of being hardcoded to Phaenna/Oizys, with support for Sinus Ardorum and future planets. Removed the "show all moons" toggle in favor of the unified planet selection.
- Overlay mission name truncation - long mission names are truncated to 35 characters with "..." instead of wrapping, with a minimum window width to prevent constant resizing.
- Overlay header buttons - settings (home/cogs) and drone finder (Oizys only) buttons moved to the overlay header row for a more compact layout, with an option to switch between home and cogs icon.
- Relic Tool XP fold state - the collapsing header now defaults to collapsed and remembers the user's fold preference across sessions.
- Planet selection sidebar reorder - moved to second slot after Cosmic Helper, with an info icon explaining that it filters both the mission list and the overlay.
- Consumable rank filter default fix - cordial and food rank filters now default to "all missions" instead of "EX+ only" to preserve existing behavior for current users.
- Various settings UI cleanup - score checkboxes on same line, icon style option next to show overlay toggle.
- Waypoint randomization improvements - outer-biased distribution (favors edge of radius), reduced max radius to 1 yalm, debug visualization via Pictomancy (togglable in settings).
- Fix jump-if-stuck ignoring config - the stuck detection now properly checks the JumpIfStuck setting before jumping.

- Retarget if stuck - alternative to jumping when stuck during nav movement, stops and re-pathfinds (re-randomizes if waypoint randomization is enabled). Radio button selection between jump/retarget with configurable stuck timer.
- Fix overlay icon button alignment - all icon buttons use consistent fixed sizing based on the widest icon to prevent layout shifts when switching between home/cogs icons.
