### PR TITLE
fix: STOP when no missions are selected but running in XPRelicOnlyEnabled

### DIFF
--- a/ICE/Scheduler/Tasks/Task_CheckMissions.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckMissions.cs
@@ -180,9 +180,7 @@ namespace ICE.Scheduler.Tasks
 
                         if (C.XPRelicOnlyEnabled)
                         {
-                            if (config.Enabled
-                                && (mission.Value.Jobs.Contains(Mission_Settings.SelectedJob)
-                                    || mission.Value.Attributes.HasFlag(MissionAttributes.Critical)))
+                            if (config.Enabled && mission.Value.Jobs.Contains(Mission_Settings.SelectedJob))
                                 MissionLibrary[LibraryInfo(mission)].Add(missionId);
                         }
                         else

--- a/ICE/Scheduler/Tasks/Task_CheckMissions.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckMissions.cs
@@ -1,5 +1,6 @@
 ﻿using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game.WKS;
+using ICE.Sounds;
 using ICE.Utilities.Cosmic_Helper;
 using ICE.Utilities.GatheringHelper;
 using System.Collections.Generic;
@@ -179,7 +180,9 @@ namespace ICE.Scheduler.Tasks
 
                         if (C.XPRelicOnlyEnabled)
                         {
-                            if (config.Enabled)
+                            if (config.Enabled
+                                && (mission.Value.Jobs.Contains(Mission_Settings.SelectedJob)
+                                    || mission.Value.Attributes.HasFlag(MissionAttributes.Critical)))
                                 MissionLibrary[LibraryInfo(mission)].Add(missionId);
                         }
                         else
@@ -274,8 +277,19 @@ namespace ICE.Scheduler.Tasks
 
             if (MissionLibrary.All(x => x.Value.Count == 0))
             {
-                IceLogging.Verbose("We currently have no viable missions... which is odd. Please make sure you have some enabled, or report back if this is incorrect\n" +
-                    $"Config Mode: {C.SelectedMode} | Mode going into this: {Mission_Settings.Mode}", tag);
+                if (modeSelected == ModeSelect.RelicMode && C.XPRelicOnlyEnabled)
+                {
+                    IceLogging.ChatInfo("\"Only selected missions\" is enabled for Relic Grind, but no selected missions match your current job. Please select missions for this job, switch jobs, or disable the option.", "[I.C.E.]");
+                    if (C.PlaySoundAlert)
+                    {
+                        _ = SoundPlayer.PlaySoundAsync();
+                    }
+                }
+                else
+                {
+                    IceLogging.Verbose("We currently have no viable missions... which is odd. Please make sure you have some enabled, or report back if this is incorrect\n" +
+                        $"Config Mode: {C.SelectedMode} | Mode going into this: {Mission_Settings.Mode}", tag);
+                }
 
                 SchedulerMain.State = IceState.Idle;
                 P.TaskManager.Tasks.Clear();


### PR DESCRIPTION
I stumbled upon this issue where the plugin would endlessly abandon missions because I set it to `Only selected missions` and forgot to select missions.

There's a guard at line 278 `if (MissionLibrary.All(x => x.Value.Count == 0))` however I believe it doesn't trigger because it just so happens that I had selected missions in another job, so the list is populated with _something_ but not any valid for the current job, which then makes the plugin endlessly loop.

I believe the appropriate fix is on that `if (config.Enabled)` I modified however i'm concerned about Red Alerts since those CAN be in different jobs, so I added an extra guard/or for it specifically as I dont want to break that scenario (where the user could have allowed say, goldsmith red alert missions, but is currently on leatherworker). So now the list is actually empty when it reaches the guard.

I also added a visible chat alert/error/stop message similar to other STOP messages so the reason is clear. Let me know if you think that extra red alert branching is uncessary (we are _technically_ in relic grind mode.. swapping to another job doesn't make much sense..) and I can drop it to a simple `config.Enabled && (mission.Value.Jobs.Contains(Mission_Settings.SelectedJob)`.