### PR TITLE
Rework leveling mode to pick missions by experience-per-minute

### DIFF
--- a/ICE/IPC/ArtisanIPC.cs
+++ b/ICE/IPC/ArtisanIPC.cs
@@ -183,7 +183,9 @@ namespace ICE.IPC
                 effectiveSettings = recipeSettings;
             }
 
-            if (isLeveling)
+            // Leveling forces progress-only for speed, except collectable crafts, which can't be turned
+            // in without quality -- keep their quality-capable solver.
+            if (isLeveling && !LevelingMissionPicker.RequiresQuality(missionId))
                 effectiveSettings.ArtisanSolverType = ArtisanCraftType.ProgressOnly;
 
             if (CraftSettings.TryGetValue(recipeId, out var cached) && ArtisanSettingsEqual(cached, effectiveSettings))

--- a/ICE/Scheduler/Tasks/Task_CheckMissions.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckMissions.cs
@@ -123,28 +123,21 @@ namespace ICE.Scheduler.Tasks
 
                 if (C.MissionConfig.TryGetValue(missionId, out var config))
                 {
-                    if (modeSelected == ModeSelect.LevelMode && CosmicHelper.QuickLevelList.Contains(mission.Key))
+                    if (modeSelected == ModeSelect.LevelMode)
                     {
+                        // Populate the library with this moon's leveling-eligible missions (job, at or
+                        // below tier, non-zero exp). Final selection happens in CheckMissions.
                         var job = Mission_Settings.SelectedJob;
-                        var jobLevel = Player.GetLevel((Job)job);
-                        var missionLevel = mission.Value.Level;
-
                         if (!mission.Value.Jobs.Contains(job))
                             continue;
 
-                        // Short end of it all, making sure to see what tier the player should be doing
-                        // Taking the players level and making sure it matches to the tier
-                        // 90+ = 90
-                        // 50-89 = 50
-                        // 10-49 = 10
-                        int playerTier = jobLevel >= 90 ? 90 : jobLevel >= 50 ? 50 : 10;
-
-                        if (missionLevel != playerTier)
+                        var jobLevel = (int)Player.GetLevel((Job)job);
+                        if (mission.Value.Level > LevelingMissionPicker.TierForLevel(jobLevel))
                             continue;
-                        else
-                        {
-                            MissionLibrary[LibraryInfo(mission)].Add(missionId);
-                        }
+                        if (LevelingMissionPicker.ExpForLevel(mission.Value, jobLevel) == 0)
+                            continue;
+
+                        MissionLibrary[LibraryInfo(mission)].Add(missionId);
                     }
                     else if (modeSelected == ModeSelect.RelicMode)
                     {
@@ -475,16 +468,27 @@ namespace ICE.Scheduler.Tasks
                 {
                     if (mode == ModeSelect.LevelMode)
                     {
-                        var levelingMission = missionList.FirstOrDefault();
-                        IceLogging.Verbose($"Leveling Mission: Job: {Mission_Settings.SelectedJob} | Mission: {levelingMission} | Level: {CosmicHelper.SheetMissionDict[levelingMission].Level}", debugOnly: true);
-                        if (basicMissionList.Contains(levelingMission))
+                        var levelingJobLevel = (int)Player.GetLevel((Job)Mission_Settings.SelectedJob);
+                        var levelingCandidates = LevelingMissionPicker.EligibleFor(
+                            Mission_Settings.SelectedJob, levelingJobLevel, basicMissionList);
+
+                        if (levelingCandidates.Count > 0)
                         {
+                            var levelingMission = LevelingMissionPicker.PickBest(levelingCandidates, levelingJobLevel);
+
+                            IceLogging.Verbose($"Leveling Mission (best EXP/min): Job: {Mission_Settings.SelectedJob} | Mission: {levelingMission} | Level: {CosmicHelper.SheetMissionDict[levelingMission].Level}", debugOnly: true);
                             LogInfo(levelingMission);
                             Insert_GrabMissionTask(levelingMission);
                             return true;
                         }
 
-                        IceLogging.Verbose($"We seem to have not found the mission. Going to double check to make sure we have the tab unlocked", tag);
+                        IceLogging.Verbose($"No EXP/min leveling candidate is currently available. Going to double check to make sure we have the tab unlocked", tag);
+
+                        if (basicMissionList.Count == 0)
+                        {
+                            IceLogging.Verbose("No basic missions are currently listed. Continuing/rerolling.", tag);
+                            return true;
+                        }
 
                         var highestRank = basicMissionList.Max(x => CosmicHelper.SheetMissionDict[x].Rank);
                         var level = Player.GetLevel((Job)Mission_Settings.SelectedJob);

--- a/ICE/Ui/DebugWindowTabs/Table_LevelingMissions.cs
+++ b/ICE/Ui/DebugWindowTabs/Table_LevelingMissions.cs
@@ -47,11 +47,12 @@ namespace ICE.Ui.DebugWindowTabs
 
                 List<uint> levels = new() { 10, 50, 90 };
 
-                // One row block per hub — Auxesia included when QuickLevelList has entries for territory 1319
+                // One row block per hub — the tier-level missions on that territory.
                 foreach (var moon in CosmicMoonRegistry.All)
                 {
-                    var levelingMissions = CosmicHelper.QuickLevelList
-                        .Where(x => CosmicHelper.SheetMissionDict[x].TerritoryId == moon.TerritoryId)
+                    var levelingMissions = CosmicHelper.SheetMissionDict
+                        .Where(x => x.Value.TerritoryId == moon.TerritoryId && levels.Contains(x.Value.Level))
+                        .Select(x => x.Key)
                         .ToList();
 
                     DrawPlanetLevelRows(moon.IconResource, levelingMissions, levels);

--- a/ICE/Ui/DebugWindowTabs/Ui_PlayerInfo.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_PlayerInfo.cs
@@ -90,10 +90,8 @@ namespace ICE.Ui.DebugWindowTabs
             {
                 foreach (var mission in C.MissionConfig)
                 {
-                    if (!CosmicHelper.QuickLevelList.Contains(mission.Key))
-                        mission.Value.Enabled = false;
-                    else
-                        mission.Value.Enabled = true;
+                    mission.Value.Enabled = CosmicHelper.SheetMissionDict.TryGetValue(mission.Key, out var info)
+                        && info.Level is 10 or 50 or 90;
                 }
                 C.SaveDebounced();
             }
@@ -179,7 +177,7 @@ namespace ICE.Ui.DebugWindowTabs
             {
                 var id = mission.Key;
 
-                if (!CosmicHelper.QuickLevelList.Contains(id))
+                if (!CosmicHelper.SheetMissionDict.TryGetValue(id, out var levelCheck) || levelCheck.Level is not (10 or 50 or 90))
                     continue;
 
                 if (CosmicHelper.SheetMissionDict.TryGetValue(id, out var missionInfo))

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Mission_Setup.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Mission_Setup.cs
@@ -161,7 +161,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                     && CosmicMoonRegistry.TryGetMoon(Player.Territory.RowId, out var currentMoon)
                     && !CosmicMoonRegistry.HasLevelingContent(currentMoon);
 
-                // Leveling on a hub requires QuickLevelList entries; gathering still needs route YAML per territory
+                // Leveling needs the hub to have crafter/gatherer missions; gathering still needs route YAML per territory
                 using (ImRaii.Disabled(SchedulerMain.State != IceState.Idle || !usingSupportedJob || unsupportedMoon))
                 {
                     if (ImGui.Button("Start", new Vector2(150 * scale, 0)))
@@ -194,7 +194,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                         ImGui.Text($"Hey! {unsupportedHub.DisplayName} is not supported for leveling yet.");
                         var missing = new List<string>();
                         if (!CosmicMoonRegistry.HasLevelingContent(unsupportedHub))
-                            missing.Add("QuickLevelList missions");
+                            missing.Add("leveling missions");
                         if (!CosmicMoonContent.HasGatheringRoutes(unsupportedHub.TerritoryId))
                             missing.Add("gathering routes");
                         if (missing.Count > 0)

--- a/ICE/Utilities/Cosmic_Helper/CosmicMissionLists.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicMissionLists.cs
@@ -4,23 +4,20 @@ using System.Linq;
 namespace ICE.Utilities.Cosmic_Helper;
 
 /// <summary>
-/// Unlock + quick-level mission IDs, rebuilt from the sheet on startup.
-/// The old giant static lists in CustomNotes.cs are gone — if a patch adds rows the heuristics miss,
-/// drop the row ID into ManualUnlockAdditions or ManualQuickLevelAdditions below.
+/// Unlock mission IDs, rebuilt from the sheet on startup.
+/// The old giant static lists in CustomNotes.cs are gone — if a patch adds rows the heuristic misses,
+/// drop the row ID into ManualUnlockAdditions below.
 /// </summary>
 public static class CosmicMissionLists
 {
     public static HashSet<uint> UnlockMissionIds { get; private set; } = [];
-    public static HashSet<uint> QuickLevelMissionIds { get; private set; } = [];
 
     // Patch gap filler — verify in the mission UI before copying +330 offsets from Oizys.
     public static HashSet<uint> ManualUnlockAdditions { get; } = [];
-    public static HashSet<uint> ManualQuickLevelAdditions { get; } = [];
 
     public static void BuildFromSheet()
     {
         UnlockMissionIds.Clear();
-        QuickLevelMissionIds.Clear();
 
         foreach (var (missionId, info) in CosmicHelper.SheetMissionDict)
         {
@@ -33,32 +30,24 @@ public static class CosmicMissionLists
             // Unlock chain: rank 1–5 standard missions on any cosmic hub
             if (info.Rank is >= 1 and <= 5)
                 UnlockMissionIds.Add(missionId);
-
-            // Level mode: A-rank missions at the 10 / 50 / 90 tiers
-            if (info.Level is 10 or 50 or 90 && info.ARank)
-                QuickLevelMissionIds.Add(missionId);
         }
 
         foreach (var id in ManualUnlockAdditions)
             UnlockMissionIds.Add(id);
-
-        foreach (var id in ManualQuickLevelAdditions)
-            QuickLevelMissionIds.Add(id);
     }
 
     public static bool IsUnlockMission(uint missionId) => UnlockMissionIds.Contains(missionId);
 
-    public static bool IsQuickLevelMission(uint missionId) => QuickLevelMissionIds.Contains(missionId);
-
     public static IEnumerable<uint> UnlockMissionList => UnlockMissionIds;
-
-    public static IEnumerable<uint> QuickLevelList => QuickLevelMissionIds;
 
     public static bool HasUnlockContent(uint territoryId) =>
         UnlockMissionIds.Any(id =>
             CosmicHelper.SheetMissionDict.TryGetValue(id, out var info) && info.TerritoryId == territoryId);
 
+    // Leveling runs off whatever missions the game offers, so a hub supports it as long as it has any
+    // crafter/gatherer mission in the sheet.
     public static bool HasLevelingContent(uint territoryId) =>
-        QuickLevelMissionIds.Any(id =>
-            CosmicHelper.SheetMissionDict.TryGetValue(id, out var info) && info.TerritoryId == territoryId);
+        CosmicHelper.SheetMissionDict.Values.Any(info =>
+            info.TerritoryId == territoryId &&
+            info.Jobs.Any(j => CosmicHelper.CrafterJobList.Contains(j) || CosmicHelper.GatheringJobList.Contains(j)));
 }

--- a/ICE/Utilities/Cosmic_Helper/CosmicMoonRegistry.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicMoonRegistry.cs
@@ -264,7 +264,7 @@ public static class CosmicMoonRegistry
     public static bool HasUnlockContent(CosmicMoonDefinition moon) =>
         CosmicMissionLists.HasUnlockContent(moon.TerritoryId);
 
-    /// <summary>True when QuickLevelList has at least one mission on this hub.</summary>
+    /// <summary>True when this hub has any crafter/gatherer mission to level on.</summary>
     public static bool HasLevelingContent(CosmicMoonDefinition moon) =>
         CosmicMissionLists.HasLevelingContent(moon.TerritoryId);
 }

--- a/ICE/Utilities/Cosmic_Helper/CustomNotes.cs
+++ b/ICE/Utilities/Cosmic_Helper/CustomNotes.cs
@@ -93,8 +93,8 @@ public static partial class CosmicHelper
             896, 938);
 
         // Auxesia (1370+): add AddMissions(...) blocks when you have SPM numbers from in-zone runs.
-        // Unlock / quick-level IDs are built automatically — see CosmicMissionLists.cs.
-        // If the sheet misses rows, use ManualUnlockAdditions / ManualQuickLevelAdditions there.
+        // Unlock IDs are built automatically — see CosmicMissionLists.cs.
+        // If the sheet misses rows, use ManualUnlockAdditions there.
 
         foreach (var mission in notesDictonary)
         {
@@ -109,9 +109,6 @@ public static partial class CosmicHelper
             dict[id] = new CustomNotes { SPM = spm, NoteInfo = note };
         }
     }
-
-    /// <summary>Filled by CosmicMissionLists.BuildFromSheet() during startup — not a hand-edited list anymore.</summary>
-    public static IEnumerable<uint> QuickLevelList => CosmicMissionLists.QuickLevelList;
 
     /// <summary>Filled by CosmicMissionLists.BuildFromSheet() during startup — not a hand-edited list anymore.</summary>
     public static IEnumerable<uint> Unlock_MissionList => CosmicMissionLists.UnlockMissionList;

--- a/ICE/Utilities/Cosmic_Helper/LevelingMissionPicker.cs
+++ b/ICE/Utilities/Cosmic_Helper/LevelingMissionPicker.cs
@@ -1,0 +1,108 @@
+using System.Collections.Generic;
+using ECommons.GameHelpers;
+using ICE.Utilities.GatheringHelper;
+
+namespace ICE.Utilities.Cosmic_Helper
+{
+    /// <summary>
+    /// Leveling-mode mission selection: out of the missions the game is currently offering for the
+    /// selected job, pick the one with the best class EXP per minute (from run-history timings).
+    /// </summary>
+    public static class LevelingMissionPicker
+    {
+        // Run time (minutes) assumed for an unmeasured mission, giving it an optimistic EXP/min so a
+        // high-exp unmeasured mission still gets probed but a low-exp one can't preempt a proven one.
+        private const double OptimisticMinutesFloor = 1.0;
+
+        // Collectable craft category codes (WKSMissionText.RowId) whose objective is "collectability
+        // will be scored" -- can't be turned in without quality, so leveling keeps the quality solver.
+        // The importer only flags gatherer collectables, not these. Progress-only codes: 99/101/140/145/236/300/309.
+        private static readonly HashSet<uint> CollectableCraftCategories = new() { 100, 102, 146, 147, 148, 235, 237, 238 };
+
+        // EXP % by player level band (in-game Class Exp table): 10-49 -> _1, 50-89 -> _2, 90+ -> _3.
+        public static uint ExpForLevel(CosmicHelper.CosmicInfo m, int jobLevel) =>
+            jobLevel >= 90 ? m.ExpModifier_3 :
+            jobLevel >= 50 ? m.ExpModifier_2 :
+                             m.ExpModifier_1;
+
+        // Leveling tier: 10 / 50 / 90.
+        public static uint TierForLevel(int jobLevel) =>
+            jobLevel >= 90 ? 90u : jobLevel >= 50 ? 50u : 10u;
+
+        // Best known run time in seconds, or 0 if never measured.
+        public static double RunSeconds(uint missionId)
+        {
+            if (!C.MissionConfig.TryGetValue(missionId, out var cfg))
+                return 0;
+            if (cfg.AverageBronzeTime > 0) return cfg.AverageBronzeTime;
+            if (cfg.AverageTime > 0) return cfg.AverageTime;
+            return 0;
+        }
+
+        // Non-fish missions are always reachable; fish missions need shipped coords or a custom hole.
+        public static bool HasTravelData(uint missionId)
+        {
+            if (!CosmicHelper.SheetMissionDict.TryGetValue(missionId, out var m))
+                return false;
+            if (!m.Attributes.HasFlag(MissionAttributes.Fish))
+                return true;
+            if (C.Personal_FishLocation.Any(f => f.ZoneId == m.TerritoryId && f.MapCoords == m.MapPosition))
+                return true;
+            return GatheringUtil.MoonFishingLocations.TryGetValue(m.TerritoryId, out var zoneHoles)
+                && zoneHoles.TryGetValue(m.MapPosition, out var spots)
+                && spots != null && spots.Count > 0;
+        }
+
+        // Leveling-eligible subset of `available`: matches the job, at or below the player's tier,
+        // grants non-zero exp at the player's level, supported, reachable.
+        public static List<uint> EligibleFor(uint job, int jobLevel, IReadOnlyCollection<uint> available)
+        {
+            var tier = TierForLevel(jobLevel);
+            var result = new List<uint>();
+            foreach (var id in available)
+            {
+                if (!CosmicHelper.SheetMissionDict.TryGetValue(id, out var m)) continue;
+                if (!m.Jobs.Contains(job)) continue;
+                if (m.Level > tier) continue;
+                if (ExpForLevel(m, jobLevel) == 0) continue;
+                if (UnsupportedMissions.Ids.Contains(id)) continue;
+                if (!HasTravelData(id)) continue;
+                result.Add(id);
+            }
+            return result;
+        }
+
+        // Whether this mission's crafts must be solved for quality. Covers gatherer/recipe collectables
+        // (the attribute) plus collectable crafts the importer misses (by category code).
+        public static bool RequiresQuality(uint missionId)
+        {
+            if (!CosmicHelper.SheetMissionDict.TryGetValue(missionId, out var m))
+                return false;
+            if (m.Attributes.HasFlag(MissionAttributes.Collectables))
+                return true;
+            if (!m.Attributes.HasFlag(MissionAttributes.Craft))
+                return false;
+            var toDoSheet = Svc.Data.GetExcelSheet<Lumina.Excel.Sheets.WKSMissionToDo>();
+            return toDoSheet != null
+                && toDoSheet.TryGetRow(m.ToDoId, out var row)
+                && CollectableCraftCategories.Contains(row.WKSMissionText.RowId);
+        }
+
+        // Best candidate by EXP/min. Measured missions use their real rate; unmeasured ones an optimistic
+        // rate so they get probed once, then converge. Returns 0 when there are no candidates.
+        public static uint PickBest(IReadOnlyCollection<uint> candidates, int jobLevel)
+        {
+            uint best = 0;
+            double bestRate = -1;
+            foreach (var id in candidates)
+            {
+                if (!CosmicHelper.SheetMissionDict.TryGetValue(id, out var m)) continue;
+                var exp = ExpForLevel(m, jobLevel);
+                var secs = RunSeconds(id);
+                var rate = secs > 0 ? exp / (secs / 60.0) : exp / OptimisticMinutesFloor;
+                if (rate > bestRate) { bestRate = rate; best = id; }
+            }
+            return best;
+        }
+    }
+}


### PR DESCRIPTION
I was doing some leveling (in leveling mode) and noticed that FSH in particular was _really, really slow_ and i also seemed to hit the issue reported on #220 where i'd see my character sit there, for 15 minutes on a single mission, cancelling/abandoning fish.

I did some investigating and figured out that the behavior was in fact correct, the preset we pass to AutoHook makes sense and the fish abandonment is correct, as we are doing a mission and need to target specific fish. But the time it took was still bothering me, the leveling slows down to a crawl at level 50 and never really recovers until level 90.

Turns out the cause was the hand picked / curated mission list, at that level range (50-90) only the collectability mission is in the curated list, and if you go by experience/mission it makes sense, that mission alone gives about 40% of an exp bar at that level range. The issue is that the mission is extremely RNG dependant, you either get the correct fish, or you sit there for 15 minutes discarding the wrong fish.

As I was in leveling mode, and the goal is to level the character I dedicded to rework the system to instead go by exp/minute and gave it a shot. A metric which we somewhat have from having done those missions before.. Plugin already tracks the time it took so might as well!

And indeed, leveling goes significantly faster with this system, since we prioritize experience/minute. For example at level ~50-60 it tends to pick the "catch 2 types of fish" mission instead of the collectable one, which can be completed in.. a minute, ish, even if unlucky. It gives about 10% of the exp bar instead of 40%.. but its way, way faster! In 4 minutes it beats the colletable one, which yeah, takes like 10-15 for my unlucky ass at least!

---

Now, i'm upstreaming these changes on a suggestion basis and you are completely on your right to refuse this as it's a major system change but I think the improvement is worth your review at least. **I'm happy to rebase/redo these changes on top of any work you have pending**!

Three things to flag:

- This is done on top of my other fix branch which i'd image will get merged (straightforward bug fix), but i'm happy to rebase if you include that fix in some other way.
- This is two commits, the first one is actually a crash/bug fix on the fish-hole lookup, when the new zone gets released the plugin if loaded would crash trying to access the array spot for an unknown location until you updated the hardcoded fishing spots. You can cherry pick this fix by itself unrelated to this, it's a genuine bug fix.
- Your curated list had a silent feature: It prevented the plugin from picking unknown/new missions that could break, this system does away with that, which is why the other fix is necessary in the first place. It's very FSH specific as gathering spots are provided by the game, only FSH spots are hardcoded, etc..

**I'm also happy to add this behind a "Smart Leveling" config flag or similar if you'd prefer that as this DOES replace the entire operation of the leveling mode from your hand-curated list into an automated system.**

Three caveats, let me know if you'd like me to change any of them:
- On cold-start (ie: no mission history data) the plugin will do every mission at least once (in leveling mode) to gather the exp-per-minute. I use your list instead or just pick the highest raw exp. New mission shows up -> we do it at least once.
- Mission duration DOES include travel time, so it's somewhat biased to stay in the same fishing spot for example (when missions share the same location), I'd say it makes sense/is fine as is (naturally cuts down on travel time), but maybe we can split that metric around to `avg_travel_time` + `avg_mission_time`.
- It does not reroll missions to find the best one, it picks the best one available, which might make the player travel around a bit more, let me know if you'd rather _only_ pick the current highest exp/minute regardless of whats available by doing rerolls.