### PR TITLE
Auxesia A-Rank gathering routes (MIN + BTN) + gather editor QOL

### DIFF
--- a/ICE/ICE.cs
+++ b/ICE/ICE.cs
@@ -162,6 +162,12 @@ public sealed partial class ICE : IDalamudPlugin
     {
         if (PlayerHelper.IsInCosmicZone())
         {
+            // Queue gather-route visuals while the debug window is open (even when
+            // collapsed), so the overlay survives folding the window. Must run before
+            // DrawPicto, which flushes the queued draw commands this frame.
+            if (debugWindow?.IsOpen == true)
+                Ui.DebugWindowTabs.Ui_GatherRoute_Editor.QueueWorldVisuals();
+
             PictoManager.DrawPicto();
         }
     }

--- a/ICE/Resources/GatheringRoutes/1319_Auxesia/BTN_Flag_-366_191.yaml
+++ b/ICE/Resources/GatheringRoutes/1319_Auxesia/BTN_Flag_-366_191.yaml
@@ -1,0 +1,93 @@
+zone_id: 1319
+zone_name: Auxesia
+job: BTN
+flag:
+  x: -366
+  y: 191
+author: Le Vagabond
+date_modified: 2026-06-03T11:48:33.0818329Z
+nodes:
+- node_id: 35798
+  position:
+    x: -404.5623
+    y: 164.2428
+    z: 191.4603
+  land_zone:
+    x: -406.2135
+    y: 163.69518
+    z: 189.57281
+  radius_start: 180
+  radius_end: 179
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35797
+  position:
+    x: -412.2761
+    y: 164.4214
+    z: 196.7626
+  land_zone:
+    x: -411.0506
+    y: 163.69519
+    z: 194.58597
+  radius_start: 49
+  radius_end: 47
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35796
+  position:
+    x: -370.4864
+    y: 164.3885
+    z: 217.8192
+  land_zone:
+    x: -371.19144
+    y: 163.69519
+    z: 215.84941
+  radius_start: 180
+  radius_end: 179
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35795
+  position:
+    x: -364.0191
+    y: 164.4268
+    z: 208.2061
+  land_zone:
+    x: -366.49146
+    y: 163.69519
+    z: 209.33192
+  radius_start: 180
+  radius_end: 179
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35799
+  position:
+    x: -338.7953
+    y: 164.357
+    z: 149.3517
+  land_zone:
+    x: -338.79636
+    y: 163.69519
+    z: 152.57187
+  radius_start: 180
+  radius_end: 179
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35800
+  position:
+    x: -347.1193
+    y: 164.7458
+    z: 161.6922
+  land_zone:
+    x: -348.6963
+    y: 163.69519
+    z: 159.66814
+  radius_start: 180
+  radius_end: 179
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0

--- a/ICE/Resources/GatheringRoutes/1319_Auxesia/BTN_Flag_528_50.yaml
+++ b/ICE/Resources/GatheringRoutes/1319_Auxesia/BTN_Flag_528_50.yaml
@@ -1,0 +1,300 @@
+zone_id: 1319
+zone_name: Auxesia
+job: BTN
+flag:
+  x: 528
+  y: 50
+author: Le Vagabond
+date_modified: 2026-06-03T11:56:43.5870030Z
+nodes:
+- node_id: 35805
+  position:
+    x: 525.8115
+    y: 185.1932
+    z: 80.17039
+  land_zone:
+    x: 527.8727
+    y: 184.28342
+    z: 78.31828
+  radius_start: 20
+  radius_end: 316
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35804
+  position:
+    x: 520.7396
+    y: 184.9751
+    z: 75.08261
+  land_zone:
+    x: 523.97565
+    y: 184.28342
+    z: 75.71582
+  radius_start: 9
+  radius_end: 338
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35803
+  position:
+    x: 508.614
+    y: 185.0666
+    z: 69.8562
+  land_zone:
+    x: 507.78708
+    y: 184.28342
+    z: 71.6237
+  radius_start: 197
+  radius_end: 158
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35801
+  position: &o0
+    x: 486.2482
+    y: 184.9927
+    z: 65.14384
+  land_zone:
+    x: 487.92502
+    y: 184.28342
+    z: 66.72849
+  radius_start: 180
+  radius_end: 179
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.51
+- node_id: 35806
+  position:
+    x: 550.4597
+    y: 184.9494
+    z: 60.87597
+  land_zone:
+    x: 548.0864
+    y: 184.28342
+    z: 61.770863
+  radius_start: 233
+  radius_end: 208
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35807
+  position:
+    x: 556.8491
+    y: 184.7477
+    z: 64.15324
+  land_zone:
+    x: 554.91876
+    y: 184.28342
+    z: 65.67201
+  radius_start: 180
+  radius_end: 179
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35808
+  position:
+    x: 564.2385
+    y: 184.786
+    z: 61.70478
+  land_zone:
+    x: 562.9329
+    y: 184.28342
+    z: 63.836945
+  radius_start: 180
+  radius_end: 179
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35814
+  position:
+    x: 525.8056
+    y: 185.186
+    z: 80.17471
+  land_zone:
+    x: 524.28986
+    y: 184.28342
+    z: 79.44156
+  radius_start: 19
+  radius_end: 316
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35813
+  position:
+    x: 520.7309
+    y: 184.9665
+    z: 75.08894
+  land_zone:
+    x: 523.38776
+    y: 184.28342
+    z: 75.37441
+  radius_start: 8
+  radius_end: 338
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35812
+  position:
+    x: 496.8279
+    y: 185.0952
+    z: 43.79417
+  land_zone:
+    x: 498.55148
+    y: 184.28342
+    z: 45.15645
+  radius_start: 180
+  radius_end: 179
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35811
+  position:
+    x: 504.0111
+    y: 185.0693
+    z: 34.75873
+  land_zone:
+    x: 504.22906
+    y: 184.28342
+    z: 35.921364
+  radius_start: 190
+  radius_end: 154
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35810
+  position:
+    x: 560.61
+    y: 185.1657
+    z: 22.56633
+  land_zone:
+    x: 559.8927
+    y: 184.28342
+    z: 22.86768
+  radius_start: 314
+  radius_end: 257
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35809
+  position:
+    x: 570.7516
+    y: 185.0807
+    z: 23.77879
+  land_zone:
+    x: 569.02563
+    y: 184.28342
+    z: 23.807484
+  radius_start: 246
+  radius_end: 218
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35815
+  position:
+    x: 538.256
+    y: 185.301
+    z: 75.73822
+  land_zone:
+    x: 537.33813
+    y: 184.28342
+    z: 73.893555
+  radius_start: 325
+  radius_end: 311
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35816
+  position:
+    x: 543.8963
+    y: 185.1837
+    z: 71.30178
+  land_zone:
+    x: 543.36743
+    y: 184.28342
+    z: 70.49972
+  radius_start: 180
+  radius_end: 179
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35818
+  position:
+    x: 545.6411
+    y: 184.8409
+    z: 33.94025
+  land_zone:
+    x: 545.75995
+    y: 184.28342
+    z: 36.270905
+  radius_start: 230
+  radius_end: 226
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35817
+  position:
+    x: 540.4255
+    y: 184.9979
+    z: 32.3407
+  land_zone:
+    x: 540.9337
+    y: 184.28336
+    z: 33.264538
+  radius_start: 230
+  radius_end: 224
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35819
+  position:
+    x: 494.6651
+    y: 184.9187
+    z: 34.07494
+  land_zone:
+    x: 494.63284
+    y: 184.28342
+    z: 35.092953
+  radius_start: 180
+  radius_end: 179
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35820
+  position:
+    x: 488.2415
+    y: 185.3008
+    z: 33.13118
+  land_zone:
+    x: 488.77826
+    y: 184.28342
+    z: 34.6695
+  radius_start: 165
+  radius_end: 123
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35801
+  position: *o0
+  land_zone:
+    x: 487.85696
+    y: 184.28342
+    z: 65.277115
+  radius_start: 0
+  radius_end: 360
+  min_distance: 1
+  max_distance: 3
+  fan_height: 0
+- node_id: 35802
+  position:
+    x: 494.3826
+    y: 185.11
+    z: 72.14518
+  land_zone:
+    x: 494.21802
+    y: 184.28342
+    z: 70.39167
+  radius_start: 0
+  radius_end: 360
+  min_distance: 1
+  max_distance: 3
+  fan_height: 0

--- a/ICE/Resources/GatheringRoutes/1319_Auxesia/MIN_Flag_-230_-454.yaml
+++ b/ICE/Resources/GatheringRoutes/1319_Auxesia/MIN_Flag_-230_-454.yaml
@@ -1,0 +1,275 @@
+zone_id: 1319
+zone_name: Auxesia
+job: MIN
+flag:
+  x: -230
+  y: -454
+author: Le Vagabond
+date_modified: 2026-06-03T09:25:58.7554199Z
+nodes:
+- node_id: 35720
+  position:
+    x: -238.6491
+    y: 145.2147
+    z: -480.2652
+  land_zone:
+    x: -235.81876
+    y: 144.42567
+    z: -479.41632
+  radius_start: 181
+  radius_end: 15
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35719
+  position:
+    x: -241.4532
+    y: 145.0885
+    z: -477.3014
+  land_zone:
+    x: -239.08594
+    y: 144.42566
+    z: -475.25256
+  radius_start: 229
+  radius_end: 164
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.28
+- node_id: 35717
+  position:
+    x: -259.6057
+    y: 145.1227
+    z: -427.234
+  land_zone:
+    x: -257.13266
+    y: 144.42567
+    z: -428.9843
+  radius_start: 88
+  radius_end: 321
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.34
+- node_id: 35718
+  position:
+    x: -246.6329
+    y: 144.8778
+    z: -433.4803
+  land_zone:
+    x: -243.56255
+    y: 144.42567
+    z: -432.54013
+  radius_start: 207
+  radius_end: 76
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35722
+  position:
+    x: -187.584
+    y: 145.4154
+    z: -445.3769
+  land_zone:
+    x: -190.42311
+    y: 144.42567
+    z: -445.06488
+  radius_start: 10
+  radius_end: 223
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35721
+  position:
+    x: -184.7121
+    y: 145.4494
+    z: -454.5209
+  land_zone:
+    x: -187.14464
+    y: 144.42567
+    z: -453.06302
+  radius_start: 299
+  radius_end: 143
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35710
+  position:
+    x: -215.8701
+    y: 145.2358
+    z: -480.3047
+  land_zone:
+    x: -217.98952
+    y: 144.42567
+    z: -477.7796
+  radius_start: 291
+  radius_end: 59
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35709
+  position:
+    x: -212.5522
+    y: 144.8581
+    z: -472.5059
+  land_zone:
+    x: -212.74684
+    y: 144.42567
+    z: -470.24826
+  radius_start: 174
+  radius_end: 8
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35708
+  position:
+    x: -199.1323
+    y: 144.8833
+    z: -463.4042
+  land_zone:
+    x: -201.53777
+    y: 144.42567
+    z: -463.82358
+  radius_start: 311
+  radius_end: 141
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35707
+  position:
+    x: -197.5123
+    y: 145.2141
+    z: -455.5029
+  land_zone:
+    x: -200.1468
+    y: 144.42567
+    z: -456.66446
+  radius_start: 43
+  radius_end: 160
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35706
+  position:
+    x: -207.614
+    y: 144.8774
+    z: -448.2607
+  land_zone:
+    x: -207.52705
+    y: 144.42567
+    z: -451.27753
+  radius_start: 348
+  radius_end: 172
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35705
+  position:
+    x: -224.4754
+    y: 144.9457
+    z: -429.3419
+  land_zone:
+    x: -223.37543
+    y: 144.42567
+    z: -431.5303
+  radius_start: 100
+  radius_end: 259
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35704
+  position:
+    x: -236.7715
+    y: 145.429
+    z: -429.7979
+  land_zone:
+    x: -236.12776
+    y: 144.42567
+    z: -432.53064
+  radius_start: 36
+  radius_end: 322
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.52
+- node_id: 35703
+  position:
+    x: -244.4014
+    y: 144.8116
+    z: -427.1371
+  land_zone:
+    x: -244.2036
+    y: 144.42567
+    z: -430.27664
+  radius_start: 100
+  radius_end: 280
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35714
+  position:
+    x: -258.3005
+    y: 145.3663
+    z: -455.1483
+  land_zone:
+    x: -256.5077
+    y: 144.42567
+    z: -456.3079
+  radius_start: 47
+  radius_end: 347
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.58
+- node_id: 35713
+  position:
+    x: -254.4164
+    y: 145.0227
+    z: -447.196
+  land_zone:
+    x: -253.07852
+    y: 144.42567
+    z: -449.64407
+  radius_start: 168
+  radius_end: 33
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35711
+  position:
+    x: -222.0998
+    y: 144.8345
+    z: -477.7647
+  land_zone:
+    x: -223.18553
+    y: 144.42567
+    z: -476.07306
+  radius_start: 250
+  radius_end: 50
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35715
+  position:
+    x: -192.8397
+    y: 145.0622
+    z: -438.1378
+  land_zone:
+    x: -193.48433
+    y: 144.42567
+    z: -439.91177
+  radius_start: 350
+  radius_end: 215
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.25
+- node_id: 35716
+  position:
+    x: -192.2584
+    y: 144.951
+    z: -430.667
+  land_zone:
+    x: -194.36034
+    y: 144.42566
+    z: -431.10843
+  radius_start: 350
+  radius_end: 190
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0

--- a/ICE/Scheduler/Tasks/Task_CheckMissions.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckMissions.cs
@@ -860,7 +860,7 @@ namespace ICE.Scheduler.Tasks
                 var mapId = sheetInfo.MapPosition;
                 var gatherInfo = GatheringRouteLoader.GetRoute(missionTerritory, mapId);
 
-                if (gatherInfo.Count == 0)
+                if (gatherInfo == null || gatherInfo.Count == 0)
                 {
                     IceLogging.Error("Hey, so this is actually missing the information for it. So going to just actually add it to the unsupported mission list", tag);
                     UnsupportedMissions.Ids.Add(missionId);

--- a/ICE/Ui/DebugWindowTabs/Ui_GatherRoute_Editor.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_GatherRoute_Editor.cs
@@ -214,6 +214,21 @@ namespace ICE.Ui.DebugWindowTabs
                         if (isClosest)
                             ImGui.PopStyleColor();
 
+                        if (ImGui.IsMouseClicked(ImGuiMouseButton.Right) && ImGui.IsItemHovered())
+                            ImGui.OpenPopup("FlagOnMapPopup");
+
+                        if (ImGui.BeginPopup("FlagOnMapPopup"))
+                        {
+                            if (ImGui.Selectable("Flag on map"))
+                            {
+                                var missionEntry = CosmicHelper.SheetMissionDict.FirstOrDefault(m => m.Value.TerritoryId == planetTerritory && m.Value.MapPosition == location);
+                                int radius = missionEntry.Value != null ? (int)missionEntry.Value.Radius : 20;
+                                string flagName = missionEntry.Value != null ? missionEntry.Value.Name : $"Gathering {location.X}, {location.Y}";
+                                Utils.SetGatheringRing(planetTerritory, (int)location.X, (int)location.Y, radius, flagName);
+                            }
+                            ImGui.EndPopup();
+                        }
+
                         ImGui.PopID();
                     }
                 }

--- a/ICE/Ui/DebugWindowTabs/Ui_GatherRoute_Editor.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_GatherRoute_Editor.cs
@@ -161,7 +161,28 @@ namespace ICE.Ui.DebugWindowTabs
                 foreach (var planet in routes)
                 {
                     var planetTerritory = planet.Key;
-                    ImGui.Text($"Zone: {planetTerritory}");
+                    ImGui.Text($"Zone: {MoonName(planetTerritory)} ({planetTerritory})");
+
+                    // For the zone the player is in, find the flag whose nodes are
+                    // physically closest, so it can be highlighted in the list.
+                    Vector2? closestFlag = null;
+                    float closestDist = float.MaxValue;
+                    if (planetTerritory == Player.Territory.RowId)
+                    {
+                        foreach (var mapLocation in planet.Value)
+                        {
+                            foreach (var node in mapLocation.Value)
+                            {
+                                float dist = Player.DistanceTo(node.Position);
+                                if (dist < closestDist)
+                                {
+                                    closestDist = dist;
+                                    closestFlag = mapLocation.Key;
+                                }
+                            }
+                        }
+                    }
+
                     foreach (var mapLocation in planet.Value)
                     {
                         var location = mapLocation.Key;
@@ -169,7 +190,10 @@ namespace ICE.Ui.DebugWindowTabs
                         ImGui.PushID($"{location}");
 
                         bool isSelected = selectedRoute == location;
+                        bool isClosest = closestFlag.HasValue && location == closestFlag.Value;
                         string selectable = isSelected ? $"-> X: {location.X}, Y: {location.Y}" : $"X: {location.X}, Y: {location.Y}";
+                        if (isClosest)
+                            selectable += "  <-";
 
                         var jobId = GetJobIdForFlag(planetTerritory, location);
 
@@ -178,11 +202,17 @@ namespace ICE.Ui.DebugWindowTabs
 
                         float availableWidth = ImGui.GetContentRegionAvail().X;
 
+                        if (isClosest)
+                            ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.4f, 1f, 0.4f, 1f));
+
                         if (ImGui.Selectable(selectable, isSelected, ImGuiSelectableFlags.None, new Vector2(availableWidth, 20)))
                         {
                             selectedRoute = location;
                             selectedZone = planetTerritory;
                         }
+
+                        if (isClosest)
+                            ImGui.PopStyleColor();
 
                         ImGui.PopID();
                     }
@@ -203,9 +233,12 @@ namespace ICE.Ui.DebugWindowTabs
                 }
                 else
                 {
-                    string missions = string.Join(", ", GetMissionsForFlag(selectedZone, selectedRoute));
                     ImGui.Text($"Location: {MoonName(selectedZone)}");
-                    ImGui.Text($"Missions: {missions}");
+                    ImGui.Text("Missions:");
+                    foreach (var mission in GetMissionsForFlag(selectedZone, selectedRoute))
+                    {
+                        ImGui.TextWrapped($"  - {mission}");
+                    }
                     ImGui.Text($"Map Zone: X:{selectedRoute.X}, Z: {selectedRoute.Y}");
 
                     ImGui.Dummy(new Vector2(0, 5));
@@ -506,14 +539,29 @@ namespace ICE.Ui.DebugWindowTabs
                         }
                     }
 
-                    if (showRouteBetween)
-                    {
-                        PictoManager.DrawGatherNodes(routeList, selectedNode, cachedWaypointPath);
-                    }
+                    // World visuals are queued from the plugin's persistent draw hook
+                    // (see QueueWorldVisuals) so they keep rendering while this window
+                    // is collapsed - the window body stops executing when folded.
                 }
             }
 
             fileDialogManager.Draw();
+        }
+
+        // Queues the selected route's world visuals (nodes, land zones, path) into
+        // PictoManager every frame, driven from the plugin's persistent draw hook.
+        // This keeps the overlay visible when the debug window is collapsed/folded,
+        // since the window body only runs while expanded. Closing the window stops it.
+        public static void QueueWorldVisuals()
+        {
+            if (!showRouteBetween || selectedRoute == Vector2.Zero)
+                return;
+
+            var routeList = GatheringRouteLoader.GetRoute(selectedZone, selectedRoute);
+            if (routeList == null)
+                return;
+
+            PictoManager.DrawGatherNodes(routeList, selectedNode, cachedWaypointPath);
         }
 
         private static uint GetJobIdForFlag(uint territoryId, Vector2 map)
@@ -534,12 +582,12 @@ namespace ICE.Ui.DebugWindowTabs
                 return 8;
         }
 
-        private static List<uint> GetMissionsForFlag(uint territoryId, Vector2 map)
+        private static List<string> GetMissionsForFlag(uint territoryId, Vector2 map)
         {
-            List<uint> missions = new();
+            List<string> missions = new();
             foreach (var mission in CosmicHelper.SheetMissionDict.Where(x => x.Value.MapPosition == map && x.Value.TerritoryId == territoryId))
             {
-                missions.Add(mission.Key);
+                missions.Add($"{mission.Value.Name} ({mission.Key})");
             }
 
             return missions;
@@ -562,7 +610,7 @@ namespace ICE.Ui.DebugWindowTabs
                     try
                     {
                         GatheringRouteLoader.ExportAllRoutes();
-                        var exportPath = GetDefaultExportPath();
+                        var exportPath = GetEffectiveExportPath();
                         _lastExportMessage = $"Successfully exported all routes to:\n{exportPath}";
                         _lastExportSuccess = true;
                         _lastExportMessageTime = DateTime.Now;
@@ -578,7 +626,7 @@ namespace ICE.Ui.DebugWindowTabs
 
                 if (ImGui.IsItemHovered())
                 {
-                    ImGui.SetTooltip("Export all routes to plugin config folder");
+                    ImGui.SetTooltip($"Export all routes to:\n{GetEffectiveExportPath()}");
                 }
 
                 DrawExportMessage();
@@ -591,7 +639,7 @@ namespace ICE.Ui.DebugWindowTabs
                     try
                     {
                         GatheringRouteLoader.ExportRoute(zoneId, flag);
-                        var exportPath = GetDefaultExportPath();
+                        var exportPath = GetEffectiveExportPath();
                         _lastExportMessage = $"Successfully exported route to:\n{exportPath}";
                         _lastExportSuccess = true;
                         _lastExportMessageTime = DateTime.Now;
@@ -607,7 +655,7 @@ namespace ICE.Ui.DebugWindowTabs
 
                 if (ImGui.IsItemHovered())
                 {
-                    ImGui.SetTooltip("Export this route to plugin config folder");
+                    ImGui.SetTooltip($"Export this route to:\n{GetEffectiveExportPath()}");
                 }
 
                 DrawExportMessage();
@@ -665,7 +713,10 @@ namespace ICE.Ui.DebugWindowTabs
                         ? new Vector4(0.0f, 1.0f, 0.0f, 1.0f)  // Green
                         : new Vector4(1.0f, 0.0f, 0.0f, 1.0f); // Red
 
-                    ImGui.TextColored(color, _lastExportMessage);
+                    using (ImRaii.PushColor(ImGuiCol.Text, color))
+                    {
+                        ImGui.TextWrapped(_lastExportMessage);
+                    }
                 }
             }
 
@@ -673,6 +724,13 @@ namespace ICE.Ui.DebugWindowTabs
             {
                 var configDir = Svc.PluginInterface.GetPluginConfigDirectory();
                 return Path.Combine(configDir, "ExportedRoutes");
+            }
+
+            // Mirrors GatheringRouteLoader's export target resolution so the success
+            // message reflects where files actually went (custom path takes precedence).
+            private static string GetEffectiveExportPath()
+            {
+                return !string.IsNullOrEmpty(C.CustomRoutePath) ? C.CustomRoutePath : GetDefaultExportPath();
             }
         }
 

--- a/ICE/Utilities/GatheringHelper/GatheringRouteLoader.cs
+++ b/ICE/Utilities/GatheringHelper/GatheringRouteLoader.cs
@@ -52,9 +52,47 @@ public static class GatheringRouteLoader
             }
         }
 
+        // Merge in routes saved on disk (custom path or exported config folder).
+        // Disk routes override embedded ones for the same zone/flag, so freshly
+        // created/captured routes appear without needing a rebuild.
+        LoadRoutesFromDisk(_cachedRoutes);
+
         PluginLog.Information($"Loaded {_cachedRoutes.Sum(x => x.Value.Count)} gathering routes across {_cachedRoutes.Count} zones");
 
         return _cachedRoutes;
+    }
+
+    private static void LoadRoutesFromDisk(Dictionary<uint, Dictionary<Vector2, List<GathNodeInfo>>> target)
+    {
+        var basePath = !string.IsNullOrEmpty(C.CustomRoutePath) ? C.CustomRoutePath : GetDefaultExportPath();
+
+        if (!Directory.Exists(basePath))
+            return;
+
+        var files = Directory.GetFiles(basePath, "*.yaml", SearchOption.AllDirectories);
+        PluginLog.Information($"Found {files.Length} gathering route files on disk at {basePath}");
+
+        foreach (var file in files)
+        {
+            try
+            {
+                var yaml = File.ReadAllText(file);
+                var route = Deserializer.Deserialize<GatheringRouteFile>(yaml);
+                if (route == null)
+                    continue;
+
+                if (!target.ContainsKey(route.ZoneId))
+                    target[route.ZoneId] = new Dictionary<Vector2, List<GathNodeInfo>>();
+
+                target[route.ZoneId][route.Flag] = route.Nodes;
+
+                PluginLog.Debug($"Loaded disk route: Zone {route.ZoneId}, Flag ({route.Flag.X}, {route.Flag.Y}), Job {route.Job}");
+            }
+            catch (Exception ex)
+            {
+                PluginLog.Error($"Failed to load route from {file}: {ex.Message}");
+            }
+        }
     }
 
     private static GatheringRouteFile LoadRouteFromResource(string resourceName)


### PR DESCRIPTION
## Summary
Adds the first A-Rank gathering routes for Auxesia (territory `1319`), plus a few QOL improvements to the gather route editor and a gather-mission crash fix. Rebased onto the latest `Main-Branch`.

## Gathering routes (Auxesia, 1319)
- **MIN** - northmost A-Rank flag `(-230, -454)`
- **BTN** - Highwood Estates (NE) flag `(528, 50)`
- **BTN** - near Pileus Pergola (middle) flag `(-366, 191)`

## Gather editor debug QOL
- **Zone + mission names in the lists**: the left zone list shows the zone name (via `CosmicMoonRegistry`) instead of just the territory id, and the route panel lists the actual mission name(s) for the selected flag instead of bare mission ids.
- **One mission per line**: the "Missions:" list renders one entry per line (wrapped) so long lists no longer run off the window edge.
- **Closest-flag highlight**: in the zone you are currently in, the flag whose nodes are physically closest to you is highlighted (green).
- **Flag on map**: right-click a flag in the list to drop a gathering ring at that flag's location, so you know where to head.
- **Persistent overlay while collapsed**: the world overlay (nodes / land zones / path) keeps drawing when the debug window is folded, instead of vanishing the moment you collapse it. It stops when the window is actually closed.
- **Correct export destination**: the "Export Selected/All Routes" success message and tooltips show the real destination (the custom route path when set, otherwise the appdata folder) and wrap within the window, instead of always claiming the default appdata path and overflowing.

## Supporting changes
- **GatheringRouteLoader**: additionally load routes from the on-disk export/custom folder (merged over the embedded ones) so captured/created routes load live without a rebuild. This is what makes the editor usable for brand-new zones.
- **Task_CheckMissions**: null-guard `GetRoute`. Gather missions for a flag with no route data (e.g. an unfinished new planet) were throwing an NRE (`gatherInfo.Count` on a null list) every scheduler tick; they now skip gracefully and get marked unsupported.

## Notes
- Zone naming routes through the existing `CosmicMoonRegistry` (no duplicate zone-name table added).
- The aethernet shard fix that was originally part of this branch is already present on `Main-Branch`, so it is no longer part of this diff.
