### PR TITLE
unified stuffs, did some cleanup, added some auxesia stuff, will be easier to maintain normally. Added comments in the code to make it easier.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,3 @@
-[submodule "ECommons"]
-	path = ECommons
-	url = https://github.com/NightmareXIV/ECommons.git
-[submodule "ffxiv_pictomancy"]
-	path = ffxiv_pictomancy
-	url = https://github.com/sourpuh/ffxiv_pictomancy
 [submodule "OtterGui"]
 	path = OtterGui
 	url = https://github.com/LeontopodiumNivale14/OtterGui

--- a/ICE.sln
+++ b/ICE.sln
@@ -3,16 +3,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.5.11716.220 stable
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ECommons", "ECommons\ECommons\ECommons.csproj", "{A5900D42-B8C9-4A1B-B87B-C8DFC92EF8FB}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{70FA308F-B135-4A66-B1D8-A3BC2C5617E1}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ICE", "ICE\ICE.csproj", "{A9C47FC4-AF93-4DEC-AE2A-BEF4184CC17C}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pictomancy", "ffxiv_pictomancy\Pictomancy\Pictomancy.csproj", "{825F17D8-2704-24F6-DF8B-2542AC92C765}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OtterGui", "OtterGui\OtterGui.csproj", "{9EC71A1C-3348-BA01-85FA-8361B6EB8537}"
 EndProject
@@ -22,18 +18,10 @@ Global
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A5900D42-B8C9-4A1B-B87B-C8DFC92EF8FB}.Debug|x64.ActiveCfg = Debug|x64
-		{A5900D42-B8C9-4A1B-B87B-C8DFC92EF8FB}.Debug|x64.Build.0 = Debug|x64
-		{A5900D42-B8C9-4A1B-B87B-C8DFC92EF8FB}.Release|x64.ActiveCfg = Release|x64
-		{A5900D42-B8C9-4A1B-B87B-C8DFC92EF8FB}.Release|x64.Build.0 = Release|x64
 		{A9C47FC4-AF93-4DEC-AE2A-BEF4184CC17C}.Debug|x64.ActiveCfg = Debug|x64
 		{A9C47FC4-AF93-4DEC-AE2A-BEF4184CC17C}.Debug|x64.Build.0 = Debug|x64
 		{A9C47FC4-AF93-4DEC-AE2A-BEF4184CC17C}.Release|x64.ActiveCfg = Release|x64
 		{A9C47FC4-AF93-4DEC-AE2A-BEF4184CC17C}.Release|x64.Build.0 = Release|x64
-		{825F17D8-2704-24F6-DF8B-2542AC92C765}.Debug|x64.ActiveCfg = Debug|x64
-		{825F17D8-2704-24F6-DF8B-2542AC92C765}.Debug|x64.Build.0 = Debug|x64
-		{825F17D8-2704-24F6-DF8B-2542AC92C765}.Release|x64.ActiveCfg = Release|x64
-		{825F17D8-2704-24F6-DF8B-2542AC92C765}.Release|x64.Build.0 = Release|x64
 		{9EC71A1C-3348-BA01-85FA-8361B6EB8537}.Debug|x64.ActiveCfg = Debug|x64
 		{9EC71A1C-3348-BA01-85FA-8361B6EB8537}.Debug|x64.Build.0 = Debug|x64
 		{9EC71A1C-3348-BA01-85FA-8361B6EB8537}.Release|x64.ActiveCfg = Release|x64

--- a/ICE/ConfigFiles/Config_Migration.cs
+++ b/ICE/ConfigFiles/Config_Migration.cs
@@ -139,8 +139,6 @@ public static class ConfigMigration
             C.JobPrio = old.JobPrio;
 
         C.AutoSelectMoon = old.AutoSelectMoon;
-        C.ShowSinusMissions = old.ShowSinusMissions;
-        C.ShowPhaennaMissions = old.ShowPhaennaMissions;
         C.RemoveAfterGold = old.RemoveAfterGold;
         C.ShowExtraMissionInfo = old.ShowExtraMissionInfo;
 

--- a/ICE/ConfigFiles/Config_Mission.cs
+++ b/ICE/ConfigFiles/Config_Mission.cs
@@ -37,9 +37,6 @@ public partial class Config
         16, 17, 18                     // Gatherers: MIN, BTN, FSH
     };
     public bool AutoSelectMoon { get; set; } = true;
-    public bool ShowSinusMissions { get; set; } = true;
-    public bool ShowPhaennaMissions { get; set; } = true;
-    public bool ShowOizysMissions { get; set; } = true;
     public bool RemoveAfterGold { get; set; } = false;
     public bool KeepARanks { get; set; } = false;
     public bool ShowExtraMissionInfo { get; set; } = true;

--- a/ICE/Enums/PlaylistOptions.cs
+++ b/ICE/Enums/PlaylistOptions.cs
@@ -8,6 +8,7 @@
         PhaennaMax = 2,
         OizysMax = 3,
         // Planet4Max = 4,
+        AuxesiaMax = 4,
         SelectedRelicLv = 5,
 
         CreditAmount = 6,

--- a/ICE/ICE.cs
+++ b/ICE/ICE.cs
@@ -329,7 +329,7 @@ public sealed partial class ICE : IDalamudPlugin
             IceLogging.Info($"Successfully loaded {routes.Count} zones with {routes.Sum(x => x.Value.Count)} total routes");
 
             // Test getting a specific route
-            var testRoute = GatheringRouteLoader.GetRoute(1237, new Vector2(-690f, -752f));
+            var testRoute = GatheringRouteLoader.GetRoute(CosmicMoonRegistry.Sinus.TerritoryId, new Vector2(-690f, -752f));
             if (testRoute != null)
             {
                 IceLogging.Info($"Test route loaded successfully with {testRoute.Count} nodes");

--- a/ICE/ICE.csproj
+++ b/ICE/ICE.csproj
@@ -54,14 +54,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="ECommons" Version="3.2.1.6" />
 		<PackageReference Include="NAudio" Version="2.3.0" />
+		<PackageReference Include="Pictomancy" Version="1.0.9" />
 		<PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.6" />
 		<PackageReference Include="YamlDotNet" Version="18.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\ECommons\ECommons\ECommons.csproj" />
-		<ProjectReference Include="..\ffxiv_pictomancy\Pictomancy\Pictomancy.csproj" />
 		<ProjectReference Include="..\OtterGui\OtterGui.csproj" />
 	</ItemGroup>
 

--- a/ICE/ICE.csproj
+++ b/ICE/ICE.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Dalamud.NET.Sdk/14.0.2">
+<Project Sdk="Dalamud.NET.Sdk/15.0.0">
 
 	<PropertyGroup>
 		<Version>0.0.78.1</Version>

--- a/ICE/ICE.csproj
+++ b/ICE/ICE.csproj
@@ -73,4 +73,11 @@
 	<ItemGroup>
 	  <Folder Include="Resources\GatheringRoutes\1310_Oizys\" />
 	</ItemGroup>
+
+	<!-- OtterGui depends on nested submodule OtterGuiInternal; init recursively if missing -->
+	<Target Name="EnsureOtterGuiSubmodules" BeforeTargets="BeforeBuild"
+	        Condition="!Exists('$(MSBuildThisFileDirectory)..\OtterGui\OtterGuiInternal\OtterGuiInternal.csproj')">
+		<Exec Command="git submodule update --init --recursive OtterGui"
+		      WorkingDirectory="$(MSBuildThisFileDirectory).." />
+	</Target>
 </Project>

--- a/ICE/ICE.csproj
+++ b/ICE/ICE.csproj
@@ -72,6 +72,7 @@
 
 	<ItemGroup>
 	  <Folder Include="Resources\GatheringRoutes\1310_Oizys\" />
+	  <Folder Include="Resources\GatheringRoutes\1319_Auxesia\" />
 	</ItemGroup>
 
 	<!-- OtterGui depends on nested submodule OtterGuiInternal; init recursively if missing -->

--- a/ICE/OldYamlConfig/MissionConfigs.cs
+++ b/ICE/OldYamlConfig/MissionConfigs.cs
@@ -83,8 +83,6 @@ namespace ICE.OldYamlConfig
             16, 17, 18                     // Gatherers: MIN, BTN, FSH
         };
         public bool AutoSelectMoon { get; set; } = true;
-        public bool ShowSinusMissions { get; set; } = true;
-        public bool ShowPhaennaMissions { get; set; } = true;
         public bool RemoveAfterGold { get; set; } = false;
         public bool ShowExtraMissionInfo { get; set; } = true;
         public Dictionary<uint, uint> ScoreKeeper { get; set; } = new();

--- a/ICE/Scheduler/Handlers/AnnouncementHandlers.cs
+++ b/ICE/Scheduler/Handlers/AnnouncementHandlers.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using ECommons.GameHelpers;
+using ICE.Utilities.Cosmic_Helper;
+using System.Collections.Generic;
 
 using JobPairs = (string job, uint territoryId, float x, float y);
 namespace ICE.Scheduler.Handlers
@@ -8,7 +10,8 @@ namespace ICE.Scheduler.Handlers
     {
         private static readonly string Announcement = "WKSAnnounce";
 
-        private static readonly Dictionary<string, (JobPairs first, JobPairs second)[]> sinusRedAlert = new()
+        // Red-alert job/flag hints per moon — only Sinus is populated; add Phaenna/Oizys/Auxesia when mapped in-game
+        private static readonly Dictionary<string, (JobPairs first, JobPairs second)[]> SinusRedAlert = new()
         {
             {
                 "meteorite shower",
@@ -50,6 +53,11 @@ namespace ICE.Scheduler.Handlers
             },
         };
 
+        private static readonly Dictionary<uint, Dictionary<string, (JobPairs first, JobPairs second)[]>> RedAlertByTerritory = new()
+        {
+            [CosmicMoonRegistry.Sinus.TerritoryId] = SinusRedAlert,
+        };
+
         internal static LocationEntry CheckForRedAlert()
         {
             if (!PlayerHelper.IsInCosmicZone()) return default;
@@ -60,11 +68,11 @@ namespace ICE.Scheduler.Handlers
                     if (AddonHelper.GetAtkTextNode(Announcement, 48)->IsVisible()) // Red Alert Preparation
                     {
                         var description = AddonHelper.GetNodeText(Announcement, 47).ToLower();
+                        var territoryId = Player.Territory.RowId;
 
-                        Dictionary<string, (JobPairs first, JobPairs second)[]>? redAlert = default;
-                        if (PlayerHelper.IsInSinusArdorum()) redAlert = sinusRedAlert; //Reassign based on Territory
+                        if (!RedAlertByTerritory.TryGetValue(territoryId, out var redAlert))
+                            return default;
 
-                        if (redAlert == default) return default;
                         return redAlert.FirstOrDefault(location => description.Contains(location.Key));
                     }
                     else

--- a/ICE/Scheduler/Handlers/AnnouncementHandlers.cs
+++ b/ICE/Scheduler/Handlers/AnnouncementHandlers.cs
@@ -10,7 +10,8 @@ namespace ICE.Scheduler.Handlers
     {
         private static readonly string Announcement = "WKSAnnounce";
 
-        // Red-alert job/flag hints per moon — only Sinus is populated; add Phaenna/Oizys/Auxesia when mapped in-game
+        // Red-alert chat hints when WKS announce fires. Sinus only for now.
+        // Phaenna / Oizys / Auxesia: copy the SinusRedAlert pattern and register in RedAlertByTerritory.
         private static readonly Dictionary<string, (JobPairs first, JobPairs second)[]> SinusRedAlert = new()
         {
             {
@@ -18,8 +19,8 @@ namespace ICE.Scheduler.Handlers
                 new(JobPairs first, JobPairs second)[]
                 {
                     (
-                        ("ARM/GSM", 1237, 22.6f, 14.9f),
-                        ("BSM/LTW/MIN", 1237, 16.3f, 24.4f)
+                        ("ARM/GSM", CosmicMoonRegistry.Sinus.TerritoryId, 22.6f, 14.9f),
+                        ("BSM/LTW/MIN", CosmicMoonRegistry.Sinus.TerritoryId, 16.3f, 24.4f)
                     )
                 }
             },
@@ -28,12 +29,12 @@ namespace ICE.Scheduler.Handlers
                 new(JobPairs first, JobPairs second)[]
                 {
                     (
-                        ("CUL/BTN/FSH", 1237, 24.5f, 16.8f),
-                        ("CRP/LTW/WVR", 1237, 29.0f, 35.4f)
+                        ("CUL/BTN/FSH", CosmicMoonRegistry.Sinus.TerritoryId, 24.5f, 16.8f),
+                        ("CRP/LTW/WVR", CosmicMoonRegistry.Sinus.TerritoryId, 29.0f, 35.4f)
                     ),
                     (
-                        ("BSM/ALC", 1237, 32.2f, 22.2f),
-                        ("CRP/WVR/BTN", 1237, 36.0f, 23.4f)
+                        ("BSM/ALC", CosmicMoonRegistry.Sinus.TerritoryId, 32.2f, 22.2f),
+                        ("CRP/WVR/BTN", CosmicMoonRegistry.Sinus.TerritoryId, 36.0f, 23.4f)
                     )
                 }
             },
@@ -42,12 +43,12 @@ namespace ICE.Scheduler.Handlers
                 new(JobPairs first, JobPairs second)[]
                 {
                     (
-                        ("ARM/GSM/ALC", 1237, 24.9f, 33.1f),
-                        ("MIN/FSH", 1237, 19.2f, 15.0f)
+                        ("ARM/GSM/ALC", CosmicMoonRegistry.Sinus.TerritoryId, 24.9f, 33.1f),
+                        ("MIN/FSH", CosmicMoonRegistry.Sinus.TerritoryId, 19.2f, 15.0f)
                     ),
                     (
-                        ("CRP/GSM/WVR", 1237, 19.8f, 36.8f),
-                        ("CUL/MIN/FSH", 1237, 12.3f, 20.0f)
+                        ("CRP/GSM/WVR", CosmicMoonRegistry.Sinus.TerritoryId, 19.8f, 36.8f),
+                        ("CUL/MIN/FSH", CosmicMoonRegistry.Sinus.TerritoryId, 12.3f, 20.0f)
                     )
                 }
             },

--- a/ICE/Scheduler/Handlers/AnnouncementHandlers.cs
+++ b/ICE/Scheduler/Handlers/AnnouncementHandlers.cs
@@ -53,10 +53,15 @@ namespace ICE.Scheduler.Handlers
             },
         };
 
-        private static readonly Dictionary<uint, Dictionary<string, (JobPairs first, JobPairs second)[]>> RedAlertByTerritory = new()
-        {
-            [CosmicMoonRegistry.Sinus.TerritoryId] = SinusRedAlert,
-        };
+        private static readonly Dictionary<string, (JobPairs first, JobPairs second)[]> EmptyRedAlert = new();
+
+        private static readonly Dictionary<uint, Dictionary<string, (JobPairs first, JobPairs second)[]>> RedAlertByTerritory =
+            CosmicMoonRegistry.All.ToDictionary(
+                m => m.TerritoryId,
+                m => m.TerritoryId == CosmicMoonRegistry.Sinus.TerritoryId ? SinusRedAlert : EmptyRedAlert);
+
+        internal static bool HasRedAlertData(uint territoryId) =>
+            RedAlertByTerritory.TryGetValue(territoryId, out var data) && data.Count > 0;
 
         internal static LocationEntry CheckForRedAlert()
         {

--- a/ICE/Scheduler/Tasks/Task_AbandonMission.cs
+++ b/ICE/Scheduler/Tasks/Task_AbandonMission.cs
@@ -1,7 +1,7 @@
 ﻿using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game.WKS;
 using ICE.Utilities.Cosmic_Helper;
-using static FFXIVClientStructs.FFXIV.Client.Game.WKS.WKSManager;
+using MissionRank = FFXIVClientStructs.FFXIV.Client.Game.WKS.WKSMissionModule.MissionRank;
 
 namespace ICE.Scheduler.Tasks
 {

--- a/ICE/Scheduler/Tasks/Task_ArtifactSearch.cs
+++ b/ICE/Scheduler/Tasks/Task_ArtifactSearch.cs
@@ -30,7 +30,7 @@ namespace ICE.Scheduler.Tasks
             string handle = "[Task_Artifact: PathTo]";
             var zoneId = Player.Territory.RowId;
 
-            if (NpcData.MoonNpcs[zoneId].TryGetValue(NpcData.NpcType.Drone, out var npcEntry))
+            if (NpcData.TryGetNpc(zoneId, NpcData.NpcType.Drone, out var npcEntry))
             {
                 Vector3 randomPos = NpcData.GetRandomPointInCircle(npcEntry.Location_Circle, 0.5f);
                 if (!Task_NavmeshMove.Task_NavTo(randomPos, distance: 6, npcLoc: npcEntry.Location_Npc).Value)
@@ -66,7 +66,7 @@ namespace ICE.Scheduler.Tasks
             }
             else
             {
-                if (NpcData.MoonNpcs[Player.Territory.RowId].TryGetValue(NpcData.NpcType.Drone, out var droneInfo))
+                if (NpcData.TryGetNpc(Player.Territory.RowId, NpcData.NpcType.Drone, out var droneInfo))
                 {
                     Utils.TryGetObjectByDataId(droneInfo.NpcId, out var droneNpc);
                     if (EzThrottler.Throttle("Interacting with researchingway"))

--- a/ICE/Scheduler/Tasks/Task_ArtifactSearch.cs
+++ b/ICE/Scheduler/Tasks/Task_ArtifactSearch.cs
@@ -170,7 +170,8 @@ namespace ICE.Scheduler.Tasks
         public static bool CanBuyDroneBoxes()
         {
             var territory = Player.Territory.RowId;
-            var dronebitInfo = CosmicHelper.DronebitInfo[territory];
+            if (!CosmicMoonRegistry.TryGetDronebit(territory, out var dronebitInfo))
+                return false;
 
             bool shouldBuyItems = false;
 
@@ -256,7 +257,10 @@ namespace ICE.Scheduler.Tasks
 
             var mapMarkers = GetAllEventMarkers();
             var marker = mapMarkers.Where(x => x.IconId == 63989).FirstOrDefault();
-            uint itemId = CosmicHelper.DronebitInfo[Player.Territory.RowId].boxId;
+            if (!CosmicMoonRegistry.TryGetDronebit(Player.Territory.RowId, out var dronebit))
+                return false;
+
+            uint itemId = dronebit.boxId;
 
             if (marker != null)
             {
@@ -347,7 +351,10 @@ namespace ICE.Scheduler.Tasks
                 }
 
                 var actionManager = ActionManager.Instance();
-                uint itemId = CosmicHelper.DronebitInfo[Player.Territory.RowId].boxId;
+                if (!CosmicMoonRegistry.TryGetDronebit(Player.Territory.RowId, out var dronebit))
+                    return false;
+
+                uint itemId = dronebit.boxId;
 
                 var status = actionManager->GetActionStatus(ActionType.Item, itemId);
 
@@ -401,7 +408,10 @@ namespace ICE.Scheduler.Tasks
         }
         private static unsafe void UseDrone()
         {
-            uint itemId = CosmicHelper.DronebitInfo[Player.Territory.RowId].boxId;
+            if (!CosmicMoonRegistry.TryGetDronebit(Player.Territory.RowId, out var dronebit))
+                return;
+
+            uint itemId = dronebit.boxId;
             var inventoryManager = InventoryManager.Instance();
 
             // Array of inventory types to check

--- a/ICE/Scheduler/Tasks/Task_BuyCosmoItems.cs
+++ b/ICE/Scheduler/Tasks/Task_BuyCosmoItems.cs
@@ -40,7 +40,7 @@ namespace ICE.Scheduler.Tasks
 
         private static bool CanPurchaseFromShop(List<uint> shoppingOrder, Dictionary<uint, Shop_Cosmocredits.ItemInfo> shopData)
         {
-            PlayerHelper.GetItemCount(45690, out var currencyAmount);
+            PlayerHelper.GetItemCount(CosmicHelper.CosmoCreditItemId, out var currencyAmount);
             currencyAmount -= C.CosmoKeepAmount;
 
             foreach (var itemId in shoppingOrder)
@@ -524,7 +524,7 @@ namespace ICE.Scheduler.Tasks
         {
             // Get current currency amount (you'll need to determine how to get this without the shop window)
 
-            PlayerHelper.GetItemCount(45690, out var currencyAmount);
+            PlayerHelper.GetItemCount(CosmicHelper.CosmoCreditItemId, out var currencyAmount);
             currencyAmount -= C.CosmoKeepAmount;
 
             // Try BuyAmount first

--- a/ICE/Scheduler/Tasks/Task_BuyCosmoItems.cs
+++ b/ICE/Scheduler/Tasks/Task_BuyCosmoItems.cs
@@ -72,7 +72,7 @@ namespace ICE.Scheduler.Tasks
             string handle = "[Task_Credits: PathTo]";
             var zoneId = Player.Territory.RowId;
 
-            if (NpcData.MoonNpcs[Player.Territory.RowId].TryGetValue(NpcData.NpcType.Credit, out var npcEntry))
+            if (NpcData.TryGetNpc(Player.Territory.RowId, NpcData.NpcType.Credit, out var npcEntry))
             {
                 Vector3 randomPos = NpcData.GetRandomPointInCircle(npcEntry.Location_Circle, 0.5f);
                 if (!Task_NavmeshMove.Task_NavTo(randomPos, distance: 6, npcLoc: npcEntry.Location_Npc).Value)
@@ -104,7 +104,7 @@ namespace ICE.Scheduler.Tasks
             }
             else
             {
-                if (NpcData.MoonNpcs[Player.Territory.RowId].TryGetValue(NpcData.NpcType.Credit, out var researchInfo))
+                if (NpcData.TryGetNpc(Player.Territory.RowId, NpcData.NpcType.Credit, out var researchInfo))
                 {
                     Utils.TryGetObjectByDataId(researchInfo.NpcId, out var researchNpc);
                     if (EzThrottler.Throttle("Interacting with researchingway"))

--- a/ICE/Scheduler/Tasks/Task_CheckMissions.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckMissions.cs
@@ -5,6 +5,7 @@ using ICE.Sounds;
 using ICE.Utilities.Cosmic_Helper;
 using ICE.Utilities.GatheringHelper;
 using System.Collections.Generic;
+using System.Linq;
 using static ECommons.UIHelpers.AddonMasterImplementations.AddonMaster;
 
 namespace ICE.Scheduler.Tasks
@@ -102,21 +103,13 @@ namespace ICE.Scheduler.Tasks
 
             var playerTerritory = Player.Territory.RowId;
 
-            var SinusCount = CosmicHelper.SheetMissionDict
-                .Where(x => C.MissionConfig[x.Key].Enabled)
-                .Where(x => x.Value.TerritoryId == 1237);
-            var PhaennaCount = CosmicHelper.SheetMissionDict
-                .Where(x => C.MissionConfig[x.Key].Enabled)
-                .Where(x => x.Value.TerritoryId == 1291);
-            var OizysCount = CosmicHelper.SheetMissionDict
-                .Where(x => C.MissionConfig[x.Key].Enabled)
-                .Where(x => x.Value.TerritoryId == 1310);
+            var enabledPerMoon = string.Join("\n",
+                CosmicMoonRegistry.All.Select(m =>
+                    $"{m.DisplayName} [{m.TerritoryId}] = [{CosmicMoonRegistry.CountEnabledMissions(m.TerritoryId)}]"));
 
             IceLogging.Info("This is just general message to let me know WHAT planet you're on, and where you have things enabled\n" +
                 "If you're not running things that requires these to be enabled, you can ignore this if you're reading this.\n" +
-                $"Sinus [1237] = [{SinusCount.Count()}]\n" +
-                $"Phaenna [1291] = [{PhaennaCount.Count()}]\n" +
-                $"Oizys [1310] = [{OizysCount.Count()}]\n" +
+                $"{enabledPerMoon}\n" +
                 $"Current TerritoryID: {playerTerritory}");
 
             var modeSelected = Mission_Settings.Mode;
@@ -435,7 +428,7 @@ namespace ICE.Scheduler.Tasks
                         }
                         case MissionTypes.DroneSearch:
                         {
-                            if (C.Cosmodrone_Run && (PlayerHelper.IsInOizys()||PlayerHelper.IsInAuxesia()))
+                            if (C.Cosmodrone_Run && CosmicMoonRegistry.TryGetMoon(Player.Territory.RowId, out var hub) && hub.HasCosmodrome)
                             {
                                 P.TaskManager.Enqueue(() => Task_ArtifactSearch.RefreshMapInfo(), "Inserting Drone Task");
                             }
@@ -896,14 +889,15 @@ namespace ICE.Scheduler.Tasks
             {
                 var location = sheetInfo.MapPosition;
                 var territory = sheetInfo.TerritoryId;
-                var fishingHole = GatheringUtil.MoonFishingLocations[territory][location];
-
-                if (fishingHole == null || fishingHole.Count == 0)
+                if (!GatheringUtil.MoonFishingLocations.TryGetValue(territory, out var zoneFishing)
+                    || !zoneFishing.TryGetValue(location, out var fishingHole)
+                    || fishingHole.Count == 0)
                 {
                     IceLogging.Error("We've seemed to have ran into a problem with the fishing hole... either it's missing spots, or it doesn't exist. Please report back to me on this with logs leading up to this\n" +
                         $"Mission ID: {missionId} | Map Position: {location} | Moon Territory: {territory}\n" +
                         $"Adding to the unsupported list so it's marked on your side for now", tag);
                     UnsupportedMissions.Ids.Add(missionId);
+                    return true;
                 }
 
                 var customFishingHole = C.Personal_FishLocation.Where(x => x.MapCoords == location).FirstOrDefault();

--- a/ICE/Scheduler/Tasks/Task_CheckMissions.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckMissions.cs
@@ -51,7 +51,6 @@ namespace ICE.Scheduler.Tasks
                     new(() => CheckTabs(), "Checking tabs for valid missions")
                 );
         }
-        private static int GrabMission_Counter = 0;
         private static void ReOpenMissionUi(string tag)
         {
             if (GenericHelpers.TryGetAddonMaster<WKSHud>("WKSHud", out var moonHud) && moonHud.IsAddonReady)

--- a/ICE/Scheduler/Tasks/Task_CheckScore.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckScore.cs
@@ -3,7 +3,7 @@ using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game.WKS;
 using ICE.Utilities.Cosmic_Helper;
 using static ECommons.UIHelpers.AddonMasterImplementations.AddonMaster;
-using static FFXIVClientStructs.FFXIV.Client.Game.WKS.WKSManager;
+using MissionRank = FFXIVClientStructs.FFXIV.Client.Game.WKS.WKSMissionModule.MissionRank;
 
 namespace ICE.Scheduler.Tasks
 {
@@ -488,29 +488,28 @@ namespace ICE.Scheduler.Tasks
             var managerPtr = WKSManager.Instance();
             if (managerPtr == null) return 0;
 
-            return managerPtr->CollectedTotal;
+            return managerPtr->State.CurrentMission.CollectedTotal;
         }
         private static unsafe uint CurrentIndividualTotal()
         {
             var managerPtr = WKSManager.Instance();
             if (managerPtr == null) return 0;
 
-            return managerPtr->CollectedIndividual;
+            return managerPtr->State.CurrentMission.CollectedIndividual;
         }
         private static unsafe uint CurrentScore()
         {
             var managerPtr = WKSManager.Instance();
             if (managerPtr == null) return 0;
 
-            var manager = managerPtr;
-            return manager->CurrentScore;
+            return managerPtr->State.CurrentMission.Score;
         }
         public static unsafe MissionRank CurrentRank()
         {
             var managerPtr = WKSManager.Instance();
             if (managerPtr == null) return MissionRank.None;
 
-            return (MissionRank)(ushort)managerPtr->CurrentRank;
+            return managerPtr->State.CurrentMission.Rank;
         }
     }
 }

--- a/ICE/Scheduler/Tasks/Task_CheckState.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckState.cs
@@ -368,13 +368,10 @@ namespace ICE.Scheduler.Tasks
                 PlayerHelper.GetItemCount(planetCreditId, out planetCreditAmount);
             }
 
+            // Dronebits exist on Oizys and Auxesia only — TryGetValue avoids throwing on Sinus/Phaenna
             int dronebitAmount = 5000;
-            // TODO: Add Auxesia Support
-            if (PlayerHelper.IsInOizys())
-            {
-                var dronebitId = CosmicHelper.DronebitInfo[territory].creditId;
-                PlayerHelper.GetItemCount(dronebitId, out dronebitAmount);
-            }
+            if (CosmicHelper.DronebitInfo.TryGetValue(territory, out var dronebit))
+                PlayerHelper.GetItemCount(dronebit.creditId, out dronebitAmount);
 
             IceLogging.Verbose("Checking to see which one we're going to start (if any)", tag);
 
@@ -418,9 +415,8 @@ namespace ICE.Scheduler.Tasks
 
                 achieved = goal switch
                 {
-                    PlaylistOptions.SinusMax => relicLevel >= 9,
-                    PlaylistOptions.PhaennaMax => relicLevel >= 14,
-                    PlaylistOptions.OizysMax => relicLevel >= 17,
+                    PlaylistOptions.SinusMax or PlaylistOptions.PhaennaMax or PlaylistOptions.OizysMax or PlaylistOptions.AuxesiaMax
+                        => relicLevel >= CosmicMoonRegistry.GetMaxRelicGoal(goal),
                     PlaylistOptions.SelectedRelicLv => relicLevel >= entry.SelectedRelicLevel,
                     PlaylistOptions.CreditAmount => creditAmount >= entry.CreditAmount,
                     PlaylistOptions.PlanetAmount => planetCreditAmount >= entry.PlanetAmount,

--- a/ICE/Scheduler/Tasks/Task_CheckState.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckState.cs
@@ -141,7 +141,8 @@ namespace ICE.Scheduler.Tasks
                 if (C.StopOnceHitLunarCredits)
                 {
                     var territory = Player.Territory.RowId;
-                    var itemId = CosmicHelper.PlanetCreditInfo[territory];
+                    if (!CosmicMoonRegistry.TryGetPlanetCreditItemId(territory, out var itemId))
+                        return false;
 
                     PlayerHelper.GetItemCount(itemId, out var credits);
                     if (credits >= C.LunarCreditsCap)
@@ -231,7 +232,8 @@ namespace ICE.Scheduler.Tasks
                 if (C.StopOnceHitLunarCredits)
                 {
                     var territory = Player.Territory.RowId;
-                    var itemId = CosmicHelper.PlanetCreditInfo[territory];
+                    if (!CosmicMoonRegistry.TryGetPlanetCreditItemId(territory, out var itemId))
+                        return false;
 
                     PlayerHelper.GetItemCount(itemId, out var credits);
                     if (credits >= C.LunarCreditsCap)
@@ -364,8 +366,8 @@ namespace ICE.Scheduler.Tasks
             var territory = Player.Territory.RowId;
             if (PlayerHelper.IsInCosmicZone())
             {
-                var planetCreditId = CosmicHelper.PlanetCreditInfo[territory];
-                PlayerHelper.GetItemCount(planetCreditId, out planetCreditAmount);
+                if (CosmicMoonRegistry.TryGetPlanetCreditItemId(territory, out var planetCreditId))
+                    PlayerHelper.GetItemCount(planetCreditId, out planetCreditAmount);
             }
 
             // Dronebits exist on Oizys and Auxesia only — TryGetValue avoids throwing on Sinus/Phaenna
@@ -413,10 +415,11 @@ namespace ICE.Scheduler.Tasks
                 var goal = entry.SelectedOption;
                 bool achieved = false;
 
+                if (CosmicMoonRegistry.IsMaxRelicPlaylistGoal(goal))
+                    achieved = relicLevel >= CosmicMoonRegistry.GetMaxRelicGoal(goal);
+                else
                 achieved = goal switch
                 {
-                    PlaylistOptions.SinusMax or PlaylistOptions.PhaennaMax or PlaylistOptions.OizysMax or PlaylistOptions.AuxesiaMax
-                        => relicLevel >= CosmicMoonRegistry.GetMaxRelicGoal(goal),
                     PlaylistOptions.SelectedRelicLv => relicLevel >= entry.SelectedRelicLevel,
                     PlaylistOptions.CreditAmount => creditAmount >= entry.CreditAmount,
                     PlaylistOptions.PlanetAmount => planetCreditAmount >= entry.PlanetAmount,

--- a/ICE/Scheduler/Tasks/Task_CheckState.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckState.cs
@@ -361,7 +361,7 @@ namespace ICE.Scheduler.Tasks
 
             var agenda = C.Cosmic_Agenda;
             var relicProgress = CosmicHelper.Cosmic_ClassInfo();
-            PlayerHelper.GetItemCount(45690, out var creditAmount);
+            PlayerHelper.GetItemCount(CosmicHelper.CosmoCreditItemId, out var creditAmount);
             int planetCreditAmount = 10000;
             var territory = Player.Territory.RowId;
             if (PlayerHelper.IsInCosmicZone())
@@ -372,7 +372,7 @@ namespace ICE.Scheduler.Tasks
 
             // Dronebits exist on Oizys and Auxesia only — TryGetValue avoids throwing on Sinus/Phaenna
             int dronebitAmount = 5000;
-            if (CosmicHelper.DronebitInfo.TryGetValue(territory, out var dronebit))
+            if (CosmicMoonRegistry.TryGetDronebit(territory, out var dronebit))
                 PlayerHelper.GetItemCount(dronebit.creditId, out dronebitAmount);
 
             IceLogging.Verbose("Checking to see which one we're going to start (if any)", tag);
@@ -514,20 +514,19 @@ namespace ICE.Scheduler.Tasks
                 return true;
             }
 
-            if (CosmicHelper.DronebitInfo.TryGetValue(territoryId, out var dronebitAmount))
+            if (CosmicMoonRegistry.TryGetDronebit(territoryId, out var dronebitAmount))
             {
                 BuyDrones = C.Cosmodrone_Buy && Task_ArtifactSearch.CanBuyDroneBoxes();
                 IceLogging.Verbose($"Buying drones? {BuyDrones}", tag);
             }
-            if (CosmicHelper.PlanetCreditInfo.TryGetValue(territoryId, out var gambaCredits) && PlayerHelper.GetItemCount(gambaCredits, out var gambaAmount))
+            if (CosmicMoonRegistry.TryGetPlanetCreditItemId(territoryId, out var gambaCredits) && PlayerHelper.GetItemCount(gambaCredits, out var gambaAmount))
             {
                 IceLogging.Verbose($"{C.GambaAtAmount} >= {gambaAmount} && Gamba between runs {C.GambaBetweenRuns}");
                 GambaWheel = C.GambaAtAmount <= gambaAmount && C.GambaBetweenRuns;
             }
             if (C.BuyItems)
             {
-                uint cosmoCreditId = 45690;
-                if (PlayerHelper.GetItemCount(cosmoCreditId, out var creditAmount))
+                if (PlayerHelper.GetItemCount(CosmicHelper.CosmoCreditItemId, out var creditAmount))
                 {
                     BuyItems = creditAmount >= C.CosmoBuyAtAmount && Task_BuyCosmoItems.CanPurchaseAnyItem();
                 }

--- a/ICE/Scheduler/Tasks/Task_Gamba.cs
+++ b/ICE/Scheduler/Tasks/Task_Gamba.cs
@@ -126,7 +126,7 @@ namespace ICE.Scheduler.Tasks
             string handle = "Task_Gamba: PathTo";
             var zoneId = Player.Territory;
 
-            if (NpcData.MoonNpcs[Player.Territory.RowId].TryGetValue(NpcData.NpcType.Gamba, out var npcEntry))
+            if (NpcData.TryGetNpc(Player.Territory.RowId, NpcData.NpcType.Gamba, out var npcEntry))
             {
                 Vector3 randomPos = NpcData.GetRandomPointInCircle(npcEntry.Location_Circle, 0.5f);
                 if (!Task_NavmeshMove.Task_NavTo(randomPos, distance: 5, npcLoc: npcEntry.Location_Npc).Value)
@@ -163,7 +163,7 @@ namespace ICE.Scheduler.Tasks
             }
             else
             {
-                if (NpcData.MoonNpcs[Player.Territory.RowId].TryGetValue(NpcData.NpcType.Gamba, out var gambaNpc))
+                if (NpcData.TryGetNpc(Player.Territory.RowId, NpcData.NpcType.Gamba, out var gambaNpc))
                 {
                     Utils.TryGetObjectByDataId(gambaNpc.NpcId, out var researchNpc);
                     if (EzThrottler.Throttle("Interacting with gambaNpc!"))
@@ -208,7 +208,9 @@ namespace ICE.Scheduler.Tasks
             if (GenericHelpers.TryGetAddonMaster<WKSLottery>("WKSLottery", out var gamba) && gamba.IsAddonReady)
             {
                 var territory = Player.Territory.RowId;
-                var itemId = CosmicHelper.PlanetCreditInfo[territory];
+                if (!CosmicMoonRegistry.TryGetPlanetCreditItemId(territory, out var itemId))
+                    return false;
+
                 PlayerHelper.GetItemCount(itemId, out var credits);
 
                 bool confirmEnabled, leftWheelEnabled, rightWheelEnabled;
@@ -286,7 +288,8 @@ namespace ICE.Scheduler.Tasks
         private static unsafe bool HasEnoughCredits()
         {
             var territory = Player.Territory.RowId;
-            var itemId = CosmicHelper.PlanetCreditInfo[territory];
+            if (!CosmicMoonRegistry.TryGetPlanetCreditItemId(territory, out var itemId))
+                return false;
 
             PlayerHelper.GetItemCount(itemId, out var credits);
             return credits >= 1000;

--- a/ICE/Scheduler/Tasks/Task_Gather.cs
+++ b/ICE/Scheduler/Tasks/Task_Gather.cs
@@ -401,8 +401,6 @@ namespace ICE.Scheduler.Tasks
 
         public static bool? PathandCheckNode()
         {
-            string tag = "Gather: Navmesh Movement";
-
             var zoneId = Player.Territory;
             var missionEntry = CosmicHelper.CurrentMissionInfo;
             var missionFlag = missionEntry.MapPosition;
@@ -887,7 +885,6 @@ namespace ICE.Scheduler.Tasks
         }
         private static bool WillOvercap(int recoveryGP)
         {
-            string tag = "Cordial: Overcap Check";
             bool WillOvercap = (PlayerHelper.GetGp() + recoveryGP) > PlayerHelper.MaxGp();
             if (WillOvercap)
             {

--- a/ICE/Scheduler/Tasks/Task_Gather.cs
+++ b/ICE/Scheduler/Tasks/Task_Gather.cs
@@ -9,7 +9,7 @@ using ICE.Utilities.GatheringHelper;
 using System.Collections.Generic;
 using static ECommons.UIHelpers.AddonMasterImplementations.AddonMaster;
 using static ICE.ConfigFiles.Config;
-using static FFXIVClientStructs.FFXIV.Client.Game.WKS.WKSManager;
+using MissionRank = FFXIVClientStructs.FFXIV.Client.Game.WKS.WKSMissionModule.MissionRank;
 
 namespace ICE.Scheduler.Tasks
 {

--- a/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
+++ b/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
@@ -581,13 +581,8 @@ namespace ICE.Scheduler.Tasks
             return true;
         }
 
-        public static Dictionary<uint, uint> PlanetProgress = new()
-        {
-            [1237] = 15,
-            [1291] = 15,
-            [1310] = 17,
-            [1319] = 2
-        };
+        public static Dictionary<uint, uint> PlanetProgress { get; } =
+            CosmicMoonRegistry.All.ToDictionary(m => m.TerritoryId, m => m.DefaultAethernetLogLevel);
 
         private static bool? CalculateAethernet(Vector3 destination)
         {
@@ -774,8 +769,13 @@ namespace ICE.Scheduler.Tasks
             {
                 if (planetInfo.TryGetValue(NpcData.NpcType.RedAlert, out var npcInfo))
                 {
+                    if (!CosmicHelper.CriticalLocations.TryGetValue(missionId, out var approxStart))
+                    {
+                        IceLogging.Warning($"No red-alert turn-in coords for mission {missionId} on {CosmicMoonRegistry.GetDisplayName(territoryId)} — add to RedAlert_Selection", tag);
+                        return true;
+                    }
+
                     var method = TravelMethods[TravelTypes.RedAlert];
-                    var approxStart = CosmicHelper.CriticalLocations[missionId];
 
                     if (_PathCalculations == null)
                     {
@@ -1052,7 +1052,11 @@ namespace ICE.Scheduler.Tasks
             if (!CosmicHelper.SheetMissionDict[missionId].IsCritical)
                 return true;
 
-            var approxStart = CosmicHelper.CriticalLocations[missionId];
+            if (!CosmicHelper.CriticalLocations.TryGetValue(missionId, out var approxStart))
+            {
+                IceLogging.Warning($"No red-alert turn-in coords for mission {missionId} — hub return via NPC skipped");
+                return true;
+            }
 
             if (CosmicHelper.HubCenter.TryGetValue(Player.Territory.RowId, out var HubCenter))
             {
@@ -1181,7 +1185,13 @@ namespace ICE.Scheduler.Tasks
             }
             else if (bestTravel.Key == TravelTypes.RedAlert)
             {
-                var redAlertNpc = NpcData.MoonNpcs[Player.Territory.RowId][NpcData.NpcType.RedAlert];
+                if (!NpcData.TryGetNpc(Player.Territory.RowId, NpcData.NpcType.RedAlert, out var redAlertNpc))
+                {
+                    IceLogging.Warning($"No red-alert NPC configured for {CosmicMoonRegistry.GetDisplayName(Player.Territory.RowId)}");
+                    P.TaskManager.Insert(() => DestinationPathing(destination, waitForBusy, distance), "Pathing to our destination: Basic");
+                    return true;
+                }
+
                 P.TaskManager.InsertMulti
                     (
                         new(() => DestinationPathing(redAlertNpc.Location_Circle), "Traveling to the Red Alert NPC"),
@@ -1191,7 +1201,13 @@ namespace ICE.Scheduler.Tasks
             }
             else if (bestTravel.Key == TravelTypes.Hub_RedAlert)
             {
-                var redAlertNpc = NpcData.MoonNpcs[Player.Territory.RowId][NpcData.NpcType.RedAlert];
+                if (!NpcData.TryGetNpc(Player.Territory.RowId, NpcData.NpcType.RedAlert, out var redAlertNpc))
+                {
+                    IceLogging.Warning($"No red-alert NPC configured for {CosmicMoonRegistry.GetDisplayName(Player.Territory.RowId)}");
+                    P.TaskManager.Insert(() => DestinationPathing(destination, waitForBusy, distance), "Pathing to our destination: Basic");
+                    return true;
+                }
+
                 P.TaskManager.InsertMulti
                     (
                         new(() => Task_Repair.HubCheck(), "Returning back to hub"),

--- a/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
+++ b/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
@@ -34,8 +34,6 @@ namespace ICE.Scheduler.Tasks
         private static Random random = new();
         private static int randomCounter = 0;
 
-        private static FishingDebug _fishingDebug = null;
-
         public enum TravelTypes
         {
             Direct,
@@ -387,7 +385,8 @@ namespace ICE.Scheduler.Tasks
         }
         public static Dictionary<uint, List<AethernetSystem>> PlanetAethernet = new()
         {
-            [1237] = new()
+            // Keys must match CosmicMoonRegistry.*.TerritoryId — validated in CosmicMoonContent.ValidateRegistry()
+            [CosmicMoonRegistry.Sinus.TerritoryId] = new()
             {
                 new()
                 {
@@ -425,7 +424,7 @@ namespace ICE.Scheduler.Tasks
                     Location = new(629.80f, -73.95f, -572.78f),
                 }
             },
-            [1291] = new()
+            [CosmicMoonRegistry.Phaenna.TerritoryId] = new()
             {
                 new()
                 {
@@ -463,7 +462,7 @@ namespace ICE.Scheduler.Tasks
                     LandZone = new(-591.95f, 28.50f, 722.10f),
                 }
             },
-            [1310] = new()
+            [CosmicMoonRegistry.Oizys.TerritoryId] = new()
             {
                 new()
                 {
@@ -502,7 +501,7 @@ namespace ICE.Scheduler.Tasks
                     RequiredLogLv = 14,
                 }
             },
-            [1319] = new()
+            [CosmicMoonRegistry.Auxesia.TerritoryId] = new()
             {
                 new()
                 {
@@ -846,7 +845,7 @@ namespace ICE.Scheduler.Tasks
         {
             string tag = "[Navmesh: Calculate Hub Path]";
 
-            if (CosmicHelper.HubCenter.TryGetValue(Player.Territory.RowId, out var HubCenter))
+            if (CosmicMoonRegistry.TryGetHubCenter(Player.Territory.RowId, out var HubCenter))
             {
                 var method = TravelMethods[TravelTypes.Hub_Return];
 
@@ -922,7 +921,7 @@ namespace ICE.Scheduler.Tasks
             var territoryId = Player.Territory.RowId;
             var planetProgress = PlanetProgress[territoryId];
 
-            if (CosmicHelper.HubCenter.TryGetValue(Player.Territory.RowId, out var HubCenter))
+            if (CosmicMoonRegistry.TryGetHubCenter(Player.Territory.RowId, out var HubCenter))
             {
                 var method = TravelMethods[TravelTypes.Hub_Aethernet];
 
@@ -1058,7 +1057,7 @@ namespace ICE.Scheduler.Tasks
                 return true;
             }
 
-            if (CosmicHelper.HubCenter.TryGetValue(Player.Territory.RowId, out var HubCenter))
+            if (CosmicMoonRegistry.TryGetHubCenter(Player.Territory.RowId, out var HubCenter))
             {
                 if (NpcData.MoonNpcs.TryGetValue(territoryId, out var planetInfo))
                 {
@@ -1224,7 +1223,6 @@ namespace ICE.Scheduler.Tasks
             return true;
         }
 
-        private static int counter = 0;
         private static unsafe bool? TravelToAethershard(PathInfo shardInfo)
         {
             string tag = "[Navmesh: Aethershard movement]";

--- a/ICE/Scheduler/Tasks/Task_RelicTurnin.cs
+++ b/ICE/Scheduler/Tasks/Task_RelicTurnin.cs
@@ -75,7 +75,7 @@ namespace ICE.Scheduler.Tasks
             string handle = "[Task_Relic: PathTo]";
             var zoneId = Player.Territory;
 
-            if (NpcData.MoonNpcs[Player.Territory.RowId].TryGetValue(NpcData.NpcType.Relic, out var npcEntry))
+            if (NpcData.TryGetNpc(Player.Territory.RowId, NpcData.NpcType.Relic, out var npcEntry))
             {
                 Vector3 randomPos = NpcData.GetRandomPointInCircle(npcEntry.Location_Circle, 0.5f);
                 if (!Task_NavmeshMove.Task_NavTo(randomPos, distance: 5, npcLoc: npcEntry.Location_Npc).Value)
@@ -114,7 +114,7 @@ namespace ICE.Scheduler.Tasks
                 }
             }
 
-            if (NpcData.MoonNpcs[Player.Territory.RowId].TryGetValue(NpcData.NpcType.Relic, out var npcEntry))
+            if (NpcData.TryGetNpc(Player.Territory.RowId, NpcData.NpcType.Relic, out var npcEntry))
             {
                 Utils.TryGetObjectByDataId(npcEntry.NpcId, out var researchNpc);
                 if (EzThrottler.Throttle("Interacting with researchingway"))

--- a/ICE/Scheduler/Tasks/Task_Repair.cs
+++ b/ICE/Scheduler/Tasks/Task_Repair.cs
@@ -51,7 +51,7 @@ namespace ICE.Scheduler.Tasks
                 return true;
             }
 
-            if (CosmicHelper.HubCenter.TryGetValue(Player.Territory.RowId, out var HubCenter))
+            if (CosmicMoonRegistry.TryGetHubCenter(Player.Territory.RowId, out var HubCenter))
             {
                 Vector3 PlayerPos = Player.Position;
 

--- a/ICE/Scheduler/Tasks/Task_Repair.cs
+++ b/ICE/Scheduler/Tasks/Task_Repair.cs
@@ -95,7 +95,7 @@ namespace ICE.Scheduler.Tasks
 
             var zoneId = Player.Territory;
 
-            if (NpcData.MoonNpcs[Player.Territory.RowId].TryGetValue(NpcData.NpcType.Repair, out var npcEntry))
+            if (NpcData.TryGetNpc(Player.Territory.RowId, NpcData.NpcType.Repair, out var npcEntry))
             {
                 Vector3 randomPos = NpcData.GetRandomPointInCircle(npcEntry.Location_Circle, 0.5f);
                 if (!Task_NavmeshMove.Task_NavTo(randomPos, distance: 5, npcLoc: npcEntry.Location_Npc).Value)
@@ -123,7 +123,7 @@ namespace ICE.Scheduler.Tasks
             var zoneId = Player.Territory;
             IGameObject? gameObject = null;
 
-            if (NpcData.MoonNpcs[Player.Territory.RowId].TryGetValue(NpcData.NpcType.Repair, out var npcEntry))
+            if (NpcData.TryGetNpc(Player.Territory.RowId, NpcData.NpcType.Repair, out var npcEntry))
             {
                 Utils.TryGetObjectByDataId(npcEntry.NpcId, out gameObject);
             }

--- a/ICE/Scheduler/Tasks/Task_StartMode.cs
+++ b/ICE/Scheduler/Tasks/Task_StartMode.cs
@@ -59,7 +59,7 @@ namespace ICE.Scheduler.Tasks
         {
             var agenda = C.Cosmic_Agenda;
             var relicProgress = CosmicHelper.Cosmic_ClassInfo();
-            PlayerHelper.GetItemCount(45690, out var creditAmount);
+            PlayerHelper.GetItemCount(CosmicHelper.CosmoCreditItemId, out var creditAmount);
             int planetCreditAmount = 10000;
             var territory = Player.Territory.RowId;
             if (PlayerHelper.IsInCosmicZone())
@@ -72,7 +72,7 @@ namespace ICE.Scheduler.Tasks
 
             // Same as AgendaCheck — only moons with a cosmodrome have dronebit currency
             int dronebitAmount = 5000;
-            if (CosmicHelper.DronebitInfo.TryGetValue(territory, out var dronebit))
+            if (CosmicMoonRegistry.TryGetDronebit(territory, out var dronebit))
                 PlayerHelper.GetItemCount(dronebit.creditId, out dronebitAmount);
 
             foreach (var entry in agenda)

--- a/ICE/Scheduler/Tasks/Task_StartMode.cs
+++ b/ICE/Scheduler/Tasks/Task_StartMode.cs
@@ -64,8 +64,10 @@ namespace ICE.Scheduler.Tasks
             var territory = Player.Territory.RowId;
             if (PlayerHelper.IsInCosmicZone())
             {
-                var planetCreditId = CosmicHelper.PlanetCreditInfo[territory];
-                PlayerHelper.GetItemCount(planetCreditId, out planetCreditAmount);
+                if (CosmicMoonRegistry.TryGetPlanetCreditItemId(territory, out var planetCreditId))
+                {
+                    PlayerHelper.GetItemCount(planetCreditId, out planetCreditAmount);
+                }
             }
 
             // Same as AgendaCheck — only moons with a cosmodrome have dronebit currency
@@ -89,10 +91,11 @@ namespace ICE.Scheduler.Tasks
                 var goal = entry.SelectedOption;
                 bool achieved = false;
 
+                if (CosmicMoonRegistry.IsMaxRelicPlaylistGoal(goal))
+                    achieved = relicLevel >= CosmicMoonRegistry.GetMaxRelicGoal(goal);
+                else
                 achieved = goal switch
                 {
-                    PlaylistOptions.SinusMax or PlaylistOptions.PhaennaMax or PlaylistOptions.OizysMax or PlaylistOptions.AuxesiaMax
-                        => relicLevel >= CosmicMoonRegistry.GetMaxRelicGoal(goal),
                     PlaylistOptions.SelectedRelicLv => relicLevel >= entry.SelectedRelicLevel,
                     PlaylistOptions.CreditAmount => creditAmount >= entry.CreditAmount,
                     PlaylistOptions.PlanetAmount => planetCreditAmount >= entry.PlanetAmount,

--- a/ICE/Scheduler/Tasks/Task_StartMode.cs
+++ b/ICE/Scheduler/Tasks/Task_StartMode.cs
@@ -68,12 +68,10 @@ namespace ICE.Scheduler.Tasks
                 PlayerHelper.GetItemCount(planetCreditId, out planetCreditAmount);
             }
 
+            // Same as AgendaCheck — only moons with a cosmodrome have dronebit currency
             int dronebitAmount = 5000;
-            if (PlayerHelper.IsInCosmicZone())
-            {
-                var dronebitId = CosmicHelper.DronebitInfo[territory].creditId;
-                PlayerHelper.GetItemCount(dronebitId, out dronebitAmount);
-            }
+            if (CosmicHelper.DronebitInfo.TryGetValue(territory, out var dronebit))
+                PlayerHelper.GetItemCount(dronebit.creditId, out dronebitAmount);
 
             foreach (var entry in agenda)
             {
@@ -93,9 +91,8 @@ namespace ICE.Scheduler.Tasks
 
                 achieved = goal switch
                 {
-                    PlaylistOptions.SinusMax => relicLevel >= 9,
-                    PlaylistOptions.PhaennaMax => relicLevel >= 14,
-                    PlaylistOptions.OizysMax => relicLevel >= 17,
+                    PlaylistOptions.SinusMax or PlaylistOptions.PhaennaMax or PlaylistOptions.OizysMax or PlaylistOptions.AuxesiaMax
+                        => relicLevel >= CosmicMoonRegistry.GetMaxRelicGoal(goal),
                     PlaylistOptions.SelectedRelicLv => relicLevel >= entry.SelectedRelicLevel,
                     PlaylistOptions.CreditAmount => creditAmount >= entry.CreditAmount,
                     PlaylistOptions.PlanetAmount => planetCreditAmount >= entry.PlanetAmount,

--- a/ICE/Scheduler/Tasks/Task_TurninMission.cs
+++ b/ICE/Scheduler/Tasks/Task_TurninMission.cs
@@ -6,7 +6,7 @@ using ICE.Utilities.Cosmic_Helper;
 using ICE.Utilities.GatheringHelper;
 using System.Collections.Generic;
 using static ECommons.UIHelpers.AddonMasterImplementations.AddonMaster;
-using static FFXIVClientStructs.FFXIV.Client.Game.WKS.WKSManager;
+using MissionRank = FFXIVClientStructs.FFXIV.Client.Game.WKS.WKSMissionModule.MissionRank;
 
 namespace ICE.Scheduler.Tasks
 {
@@ -251,7 +251,6 @@ namespace ICE.Scheduler.Tasks
                             {
                                 MissionRank.Gold => TurninState.Gold,
                                 MissionRank.Silver => TurninState.Silver,
-                                MissionRank.Bronze => TurninState.Bronze,
                                 _ => TurninState.Bronze,
                             };
                         }

--- a/ICE/Sounds/SoundPlayer.cs
+++ b/ICE/Sounds/SoundPlayer.cs
@@ -11,7 +11,6 @@ namespace ICE.Sounds
     public static class SoundPlayer
     {
         private static byte[]? _soundData;
-        private static WasapiOut? _waveOut;
         private static bool _initialized = false;
 
         // Call this once during plugin init, off the main thread

--- a/ICE/Ui/DebugWindowTabs/Hud_MissionInfo.cs
+++ b/ICE/Ui/DebugWindowTabs/Hud_MissionInfo.cs
@@ -8,16 +8,8 @@ namespace ICE.Ui.DebugWindowTabs
     {
         public static unsafe void Draw()
         {
-            uint currentScore = 0;
-            uint silverScore = 0;
-            uint goldScore = 0;
-
             if (GenericHelpers.TryGetAddonMaster<WKSMissionInfomation>("WKSMissionInfomation", out var x) && x.IsAddonReady)
             {
-                // currentScore = x.CurrentScore;
-                // silverScore = x.SilverScore;
-                // goldScore = x.GoldScore;
-
                 var isAddonReady = AddonHelper.IsAddonActive("WKSMissionInfomation");
                 ImGui.Text($"Addon Ready: {isAddonReady}");
                 if (isAddonReady)

--- a/ICE/Ui/DebugWindowTabs/Hud_MissionInfo.cs
+++ b/ICE/Ui/DebugWindowTabs/Hud_MissionInfo.cs
@@ -127,23 +127,24 @@ namespace ICE.Ui.DebugWindowTabs
                     }
 
                     var wks = WKSManager.Instance();
+                    if (wks == null)
+                        return;
+
+                    var scores = wks->State.Scores;
 
                     ImGui.TableNextRow();
                     ImGui.TableSetColumnIndex(0);
                     ImGui.Text("Score 1");
                     ImGui.TableNextColumn();
-                    ImGui.Text($"{wks->Scores.Length}");
+                    ImGui.Text($"{scores.Length}");
 
-                    int score = 0;
-
-                    foreach (var item in wks->Scores)
+                    for (int score = 0; score < scores.Length; score++)
                     {
                         ImGui.TableNextRow();
                         ImGui.TableSetColumnIndex(0);
                         ImGui.Text($"Score: [{score}]");
                         ImGui.TableNextColumn();
-                        ImGui.Text($"{wks->Scores[score]}");
-                        score += 1;
+                        ImGui.Text($"{scores[score]}");
                     }
 
                     /*
@@ -171,7 +172,7 @@ namespace ICE.Ui.DebugWindowTabs
             var managerPtr = WKSManager.Instance();
             if (managerPtr == null) return 0;
 
-            return managerPtr->CurrentScore;
+            return managerPtr->State.CurrentMission.Score;
         }
     }
 }

--- a/ICE/Ui/DebugWindowTabs/Table_LevelingMissions.cs
+++ b/ICE/Ui/DebugWindowTabs/Table_LevelingMissions.cs
@@ -45,15 +45,17 @@ namespace ICE.Ui.DebugWindowTabs
                     ImGui.Image(image.JobIcon.GetWrapOrEmpty().Handle, new Vector2(imgSize));
                 }
 
-                List<uint> sinusLeveling = CosmicHelper.QuickLevelList.Where(x => CosmicHelper.SheetMissionDict[x].TerritoryId == 1237).ToList();
-                List<uint> phaennaLeveling = CosmicHelper.QuickLevelList.Where(x => CosmicHelper.SheetMissionDict[x].TerritoryId == 1291).ToList();
-                List<uint> oizysLeveling = CosmicHelper.QuickLevelList.Where(x => CosmicHelper.SheetMissionDict[x].TerritoryId == 1310).ToList();
-
                 List<uint> levels = new() { 10, 50, 90 };
 
-                DrawPlanetLevelRows("ICE.Resources.Sinus_Ardorum.png", sinusLeveling, levels);
-                DrawPlanetLevelRows("ICE.Resources.Phaenna.png", phaennaLeveling, levels);
-                DrawPlanetLevelRows("ICE.Resources.Oizys.png", oizysLeveling, levels);
+                // One row block per hub — Auxesia included when QuickLevelList has entries for territory 1319
+                foreach (var moon in CosmicMoonRegistry.All)
+                {
+                    var levelingMissions = CosmicHelper.QuickLevelList
+                        .Where(x => CosmicHelper.SheetMissionDict[x].TerritoryId == moon.TerritoryId)
+                        .ToList();
+
+                    DrawPlanetLevelRows(moon.IconResource, levelingMissions, levels);
+                }
 
                 ImGui.EndTable();
             }

--- a/ICE/Ui/DebugWindowTabs/Table_MissionInfo.cs
+++ b/ICE/Ui/DebugWindowTabs/Table_MissionInfo.cs
@@ -54,6 +54,43 @@ namespace ICE.Ui.DebugWindowTabs
             }
             ImGui.SameLine();
 
+            if (ImGui.Button("Copy Missing CSV"))
+            {
+                var text = MissionScoresGenerator.BuildCsvText(includeHeader: true);
+                var count = MissionScoresGenerator.CountMissing();
+                if (count > 0)
+                {
+                    ImGui.SetClipboardText(text);
+                    statusMessage = $"Copied {count} missing MissionScores rows (bronze) to clipboard";
+                }
+                else
+                    statusMessage = "No missing rows — embedded CSV covers all missions with bronze scores.";
+            }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.Text("Rows for missions not in MissionScores.csv, using BronzeScore from sheets.");
+                ImGui.Text("Paste at end of Resources/MissionScores.csv");
+                ImGui.EndTooltip();
+            }
+
+            ImGui.SameLine();
+
+            if (ImGui.Button("Copy Auxesia CSV"))
+            {
+                var text = MissionScoresGenerator.BuildCsvText(CosmicMoonRegistry.Auxesia.TerritoryId, includeHeader: false);
+                var count = MissionScoresGenerator.CountMissing(CosmicMoonRegistry.Auxesia.TerritoryId);
+                if (count > 0)
+                {
+                    ImGui.SetClipboardText(text);
+                    statusMessage = $"Copied {count} Auxesia rows to clipboard";
+                }
+                else
+                    statusMessage = "No missing Auxesia MissionScores rows.";
+            }
+
+            ImGui.SameLine();
+
             if (ImGui.Button("Export Fishing Missions"))
             {
                 var fishingMissions = CosmicHelper.SheetMissionDict
@@ -106,6 +143,17 @@ namespace ICE.Ui.DebugWindowTabs
                         }
                     }
                 );
+            }
+
+            ImGui.SameLine();
+            if (ImGui.Button("Export Missing CSV"))
+            {
+                if (string.IsNullOrWhiteSpace(exportPath))
+                    statusMessage = "Set export path first (or use Copy Missing CSV)";
+                else if (MissionScoresGenerator.TryExportMissingRows(exportPath, out var msg))
+                    statusMessage = msg;
+                else
+                    statusMessage = msg;
             }
 
             ImGui.SameLine();

--- a/ICE/Ui/DebugWindowTabs/Ui_Fish_HoleEditor.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_Fish_HoleEditor.cs
@@ -72,7 +72,7 @@ namespace ICE.Ui.DebugWindowTabs
             }
 
             ImGui.Checkbox("Show fishing spot raycast", ref _fishingDebug.ShowFishRay);
-            if (PlayerHelper.LocalPlayer is { } player && _fishingDebug.ShowFishRay)
+            if (Player.Object is { } player && _fishingDebug.ShowFishRay)
             {
                 _fishingDebug.Draw();
             }

--- a/ICE/Ui/DebugWindowTabs/Ui_FishingRaycast.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_FishingRaycast.cs
@@ -1,4 +1,5 @@
-﻿using FFXIVClientStructs.FFXIV.Client.System.Framework;
+﻿using ECommons.GameHelpers;
+using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Common.Component.BGCollision;
 using ICE.Utilities.Cosmic_Helper;
 using System.Collections.Generic;
@@ -46,7 +47,7 @@ namespace ICE.Ui.DebugWindowTabs
         /// <returns>True if fishable, false otherwise</returns>
         public bool IsFishable(float? rotation = null)
         {
-            if (PlayerHelper.LocalPlayer is not { } player)
+            if (Player.Object is not { } player)
                 return false;
 
             if (_raycastSimple == null)
@@ -68,7 +69,7 @@ namespace ICE.Ui.DebugWindowTabs
         {
             fishablePosition = null;
 
-            if (PlayerHelper.LocalPlayer is not { } player)
+            if (Player.Object is not { } player)
                 return false;
 
             if (_raycastSimple == null)
@@ -164,7 +165,7 @@ namespace ICE.Ui.DebugWindowTabs
         {
             var fishableLocations = new List<(Vector3, float)>();
 
-            if (PlayerHelper.LocalPlayer is not { } player)
+            if (Player.Object is not { } player)
                 return fishableLocations;
 
             if (_raycastSimple == null)
@@ -264,7 +265,7 @@ namespace ICE.Ui.DebugWindowTabs
 
         public void Draw()
         {
-            if (PlayerHelper.LocalPlayer is not { } player)
+            if (Player.Object is not { } player)
                 return;
 
             if (!ShowFishRay)

--- a/ICE/Ui/DebugWindowTabs/Ui_GatherRoute_Editor.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_GatherRoute_Editor.cs
@@ -18,10 +18,8 @@ namespace ICE.Ui.DebugWindowTabs
         private static uint selectedZone = 0;
         private static uint selectedNode = 0;
 
-        private static bool showOnlyVisibleNodes = false;
         private static float maxDistance = 75.0f;
 
-        private static bool showSelectedNode = false;
         private static bool showRouteBetween = true;
 
         private static bool _isGeneratingFan = false;

--- a/ICE/Ui/DebugWindowTabs/Ui_GatherRoute_Editor.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_GatherRoute_Editor.cs
@@ -547,17 +547,9 @@ namespace ICE.Ui.DebugWindowTabs
             return missions;
         }
 
-        private static string MoonName(uint territoryId)
-        {
-            if (territoryId == 1237)
-                return "Sinus Ardorum";
-            else if (territoryId == 1291)
-                return "Phaenna";
-            else
-            {
-                return "???";
-            }
-        }
+        // territoryId is TerritoryType (1319), not WKSMissionUnit row ID
+        private static string MoonName(uint territoryId) =>
+            CosmicMoonRegistry.GetDisplayName(territoryId);
 
         public static class GatheringRouteExportUI
         {

--- a/ICE/Ui/DebugWindowTabs/Ui_MapTesting.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_MapTesting.cs
@@ -1,4 +1,6 @@
-﻿using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+﻿using ECommons.GameHelpers;
+using FFXIVClientStructs.FFXIV.Client.UI.Agent;
+using ICE.Utilities;
 using ICE.Utilities.Cosmic_Helper;
 
 namespace ICE.Ui.DebugWindowTabs
@@ -25,7 +27,11 @@ namespace ICE.Ui.DebugWindowTabs
                 int _radius = MapInfo.GetRow((uint)TableRow).Radius.ToInt();
                 IceLogging.Debug($"X: {_x} Y: {_y} Radius: {_radius}");
 
-                Utils.SetGatheringRing(1237, _x, _y, _radius);
+                // In cosmic zone use where you are; otherwise Sinus so debug tools still work out of hub.
+                var territoryId = PlayerHelper.IsInCosmicZone()
+                    ? Player.Territory.RowId
+                    : CosmicMoonRegistry.Sinus.TerritoryId;
+                Utils.SetGatheringRing(territoryId, _x, _y, _radius);
             }
             ImGui.SetNextItemWidth(125);
             ImGui.InputInt("Map X (Sheet)", ref posX);

--- a/ICE/Ui/DebugWindowTabs/Ui_NavmeshTesting.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_NavmeshTesting.cs
@@ -1,4 +1,5 @@
-﻿using Pictomancy;
+﻿using ECommons.GameHelpers;
+using Pictomancy;
 using System.Collections.Generic;
 
 namespace ICE.Ui.DebugWindowTabs
@@ -7,23 +8,19 @@ namespace ICE.Ui.DebugWindowTabs
     {
         private static List<Vector3> finalPath = new List<Vector3>();
         private static Vector3 currentPos = new Vector3();
-        private static Vector3 BaseCenter = new Vector3(0, 0, 0);
-        private static float radius = 12f;
-        private static int numCircleWps = 50;
         private static List<Vector3> wholePath = new List<Vector3>();
 
         // Picto Stuff
         private static float lineWidth = 0;
         private static float dotRadius = 4.2f;
-        private static uint CircleColor = 2616716297;
         private static uint LineColor = 804847871;
         private static uint WPColor = 4294180358;
         private static uint TextCol = 2667577343;
 
         public static void Draw()
         {
-            if (PlayerHelper.LocalPlayer != null)
-                currentPos = PlayerHelper.LocalPlayer.Position;
+            if (Player.Object != null)
+                currentPos = Player.Object.Position;
             else
                 currentPos = new Vector3(0, 0, 0);
 

--- a/ICE/Ui/DebugWindowTabs/Ui_PlayerInfo.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_PlayerInfo.cs
@@ -54,7 +54,7 @@ namespace ICE.Ui.DebugWindowTabs
             if (PlayerHelper.IsInCosmicZone())
             {
                 var manager = WKSManager.Instance();
-                var currentMission = manager->CurrentMissionUnitRowId;
+                var currentMission = manager->State.CurrentMission.MissionUnitRowId;
 
                 ImGui.Text($"Current Mission: {currentMission}");
             }
@@ -296,7 +296,7 @@ namespace ICE.Ui.DebugWindowTabs
             if (wks == null)
                 return 0;
 
-            return wks->DevGrade;
+            return wks->State.DevGrade;
         }
     }
 }

--- a/ICE/Ui/DebugWindowTabs/Ui_PlayerInfo.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_PlayerInfo.cs
@@ -202,8 +202,6 @@ namespace ICE.Ui.DebugWindowTabs
             return bestMission;
         }
 
-        private static uint selectedId = 0;
-
         private static void DroidCheck()
         {
             if (ImGui.CollapsingHeader("Object info"))

--- a/ICE/Ui/DebugWindowTabs/Ui_RelicInfo.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_RelicInfo.cs
@@ -76,7 +76,7 @@ namespace ICE.Ui.DebugWindowTabs
                     }
 
                     ImGui.TableSetColumnIndex(14);
-                    var scores = wksManager->Scores;
+                    var scores = wksManager->State.Scores;
                     int classScore = scores[(int)job.Id - 8];
 
                     ImGui.TextUnformatted($"{classScore}");

--- a/ICE/Ui/DebugWindowTabs/Ui_TaskManagerInfo.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_TaskManagerInfo.cs
@@ -7,7 +7,6 @@ namespace ICE.Ui.DebugWindowTabs
     internal class Ui_TaskManagerInfo
     {
         private static uint mission = 0;
-        private static int frameDelay = 4;
         private static List<Vector3> pathTo = new List<Vector3>();
         private static Vector3 pathToArea = new Vector3();
 

--- a/ICE/Ui/DebugWindowTabs/Ui_TestButtons.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_TestButtons.cs
@@ -241,7 +241,7 @@ namespace ICE.Ui.DebugWindowTabs
             //  1          - Unknown 10
             //  1          - Unknown 11
 
-            ImGui.Text($"{WKSManager.Instance()->CurrentMissionUnitRowId}");
+            ImGui.Text($"{WKSManager.Instance()->State.CurrentMission.MissionUnitRowId}");
 
             if (ImGui.Button("Test Drone Buy"))
             {

--- a/ICE/Ui/DebugWindowTabs/Ui_TestButtons.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_TestButtons.cs
@@ -3,6 +3,7 @@ using FFXIVClientStructs.FFXIV.Client.Game.WKS;
 using System.Collections.Generic;
 using System.Text;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using ICE.Utilities;
 using ICE.Utilities.Cosmic_Helper;
 
 namespace ICE.Ui.DebugWindowTabs
@@ -286,7 +287,7 @@ namespace ICE.Ui.DebugWindowTabs
             var gameObject = Utils.TryGetObjectNearestEventObject();
             float gameObjectDistance = 0;
             if (gameObject is not null)
-                gameObjectDistance = PlayerHelper.GetDistanceToPlayer(gameObject);
+                gameObjectDistance = Player.DistanceTo(gameObject);
             if (ImGui.Button("Click Nearest EventObject"))
             {
                 Utils.TargetgameObjectTask(gameObject);
@@ -298,7 +299,7 @@ namespace ICE.Ui.DebugWindowTabs
             var collectionPoint = Utils.TryGetObjectCollectionPoint();
             float collectionPointDistance = 0;
             if (collectionPoint is not null)
-                collectionPointDistance = PlayerHelper.GetDistanceToPlayer(collectionPoint);
+                collectionPointDistance = Player.DistanceTo(collectionPoint);
             if (ImGui.Button("Click Nearest Collection Point"))
             {
                 Utils.TargetgameObjectTask(collectionPoint);
@@ -309,7 +310,7 @@ namespace ICE.Ui.DebugWindowTabs
 
             if (ImGui.Button("Print GatheringPoint Info"))
             {
-                var gatheringPoint = PlayerHelper.LocalPlayer.TargetObject;
+                var gatheringPoint = Player.Object?.TargetObject;
                 if (gatheringPoint is not null)
                 {
                     var nodeId = gatheringPoint.BaseId;
@@ -319,7 +320,11 @@ namespace ICE.Ui.DebugWindowTabs
                     var currentMission = CosmicHelper.CurrentMissionInfo;
                     var nodeSet = currentMission?.MapPosition ?? new Vector2(0, 0);
 
-                    string info = $"new GathNodeInfo\n{{\n    ZoneId = 1237,\n    NodeId = {nodeId},\n    Position = new Vector3({position.X}f, {position.Y}f, {position.Z}f),\n    LandZone = new Vector3({landZone.X}f, {landZone.Y}f, {landZone.Z}f),\n    GatheringType = {gatheringType},\n    NodeSet = {nodeSet}\n}}";
+                    // In cosmic zone use where you are; otherwise Sinus so clipboard export still works.
+                    var zoneId = PlayerHelper.IsInCosmicZone()
+                        ? Player.Territory.RowId
+                        : CosmicMoonRegistry.Sinus.TerritoryId;
+                    string info = $"new GathNodeInfo\n{{\n    ZoneId = {zoneId},\n    NodeId = {nodeId},\n    Position = new Vector3({position.X}f, {position.Y}f, {position.Z}f),\n    LandZone = new Vector3({landZone.X}f, {landZone.Y}f, {landZone.Z}f),\n    GatheringType = {gatheringType},\n    NodeSet = {nodeSet}\n}}";
 
                     ImGui.SetClipboardText(info);
                     Svc.Chat.Print(info);

--- a/ICE/Ui/MainUi/ModeSelect_Modes/CosmicTable/Mission_Table.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/CosmicTable/Mission_Table.cs
@@ -7,6 +7,7 @@ using JetBrains.Annotations;
 using OtterGui;
 using OtterGui.Table;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using static ICE.ConfigFiles.Config;
 using static ICE.Utilities.Cosmic_Helper.CosmicHelper;
@@ -815,8 +816,9 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes.CosmicTable
             public PlanetColumn()
             {
                 Flags = ImGuiTableColumnFlags.None;
-                SetFlags(ItemFilter.Sinus, ItemFilter.Phaenna, ItemFilter.Oizys, ItemFilter.Auxesia);
-                SetNames("Sinus", "Phaenna", "Oizys", "Auxesia");
+                var moons = CosmicMoonRegistry.All;
+                SetFlags(moons.Select(m => m.PlanetFilter).ToArray());
+                SetNames(moons.Select(m => m.DisplayName).ToArray());
             }
 
             public override int Compare(MissionInfo lhs, MissionInfo rhs) => lhs.SheetInfo.TerritoryId.CompareTo(rhs.SheetInfo.TerritoryId);
@@ -829,29 +831,13 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes.CosmicTable
                 var columnWidth = ImGui.GetColumnWidth();
                 ImGui.SetCursorPosX(ImGui.GetCursorPosX() + (columnWidth - frameHeight) / 2);
 
-                string planetIcon = item.SheetInfo.TerritoryId switch
-                {
-                    1237 => "ICE.Resources.Sinus_Ardorum.png",
-                    1291 => "ICE.Resources.Phaenna.png",
-                    1310 => "ICE.Resources.Oizys.png",
-                    1319 => "ICE.Resources.Auxesia.png",
-                    _ => "ICE.Resources.Sinus_Ardorum.png",
-                };
+                var planetIcon = CosmicMoonRegistry.GetIconResource(item.SheetInfo.TerritoryId);
 
                 var texture = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), planetIcon).GetWrapOrEmpty();
                 ImGui.Image(texture.Handle, size);
             }
-            public override bool FilterFunc(MissionInfo item)
-            {
-                return item.SheetInfo.TerritoryId switch
-                {
-                    1237 => FilterValue.HasFlag(ItemFilter.Sinus),
-                    1291 => FilterValue.HasFlag(ItemFilter.Phaenna),
-                    1310 => FilterValue.HasFlag(ItemFilter.Oizys),
-                    1319 => FilterValue.HasFlag(ItemFilter.Auxesia),
-                    _ => false
-                };
-            }
+            public override bool FilterFunc(MissionInfo item) =>
+                CosmicMoonRegistry.ItemFilterIncludesTerritory(FilterValue, item.SheetInfo.TerritoryId);
         }
         public sealed class JobColumn : JobFilterColumn
         {

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Cosmic_Agenda.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Cosmic_Agenda.cs
@@ -20,6 +20,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
             PlaylistOptions.SinusMax,
             PlaylistOptions.PhaennaMax,
             PlaylistOptions.OizysMax,
+            PlaylistOptions.AuxesiaMax,
             PlaylistOptions.ToolMaxExp,
             PlaylistOptions.SelectedRelicLv,
 
@@ -124,7 +125,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                         if (ImGui.Button("Add to Cosmic Agenda"))
                         {
                             var mode = ModeSelect.Standard;
-                            if (SelectedOption is PlaylistOptions.SinusMax or PlaylistOptions.PhaennaMax or PlaylistOptions.OizysMax or PlaylistOptions.SelectedRelicLv)
+                            if (SelectedOption is PlaylistOptions.SinusMax or PlaylistOptions.PhaennaMax or PlaylistOptions.OizysMax or PlaylistOptions.AuxesiaMax or PlaylistOptions.SelectedRelicLv)
                             {
                                 mode = ModeSelect.RelicMode;
                             }
@@ -571,60 +572,25 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
 
                             ImGui.EndCombo();
                         }
+                        // Same standard-mission check for every hub — driven by CosmicMoonRegistry, not per-moon copy/paste
                         if (currentMode == ModeSelect.Standard && PlayerHelper.IsInCosmicZone())
                         {
-                            var SinusStandard = CosmicHelper.SheetMissionDict.Where(x => x.Value.TerritoryId == 1237)
-                                .Where(x => C.MissionConfig.ContainsKey(x.Key))
-                                .Where(x => C.MissionConfig[x.Key].Enabled)
-                                .Where(x => x.Value.Jobs.Contains(agendaInfo.SelectedJob))
-                                .Where(x => x.Value.Rank < 6)
-                                .Count();
-
-                            var PhaennaStandard = CosmicHelper.SheetMissionDict.Where(x => x.Value.TerritoryId == 1291)
-                                .Where(x => C.MissionConfig.ContainsKey(x.Key))
-                                .Where(x => C.MissionConfig[x.Key].Enabled)
-                                .Where(x => x.Value.Jobs.Contains(agendaInfo.SelectedJob))
-                                .Where(x => x.Value.Rank < 6)
-                                .Count();
-
-                            var OizysStandard = CosmicHelper.SheetMissionDict.Where(x => x.Value.TerritoryId == 1310)
-                                .Where(x => C.MissionConfig.ContainsKey(x.Key))
-                                .Where(x => C.MissionConfig[x.Key].Enabled)
-                                .Where(x => x.Value.Jobs.Contains(agendaInfo.SelectedJob))
-                                .Where(x => x.Value.Rank < 6)
-                                .Count();
-
-                            var AuxesiaStandard = CosmicHelper.SheetMissionDict.Where(x => x.Value.TerritoryId == 1317)
-                                .Where(x => C.MissionConfig.ContainsKey(x.Key))
-                                .Where(x => C.MissionConfig[x.Key].Enabled)
-                                .Where(x => x.Value.Jobs.Contains(agendaInfo.SelectedJob))
-                                .Where(x => x.Value.Rank < 6)
-                                .Count();
-
-                            bool sinusWarning = PlayerHelper.IsInSinusArdorum() && SinusStandard == 0;
-                            bool phaennaWarning = PlayerHelper.IsInPhaenna() && PhaennaStandard == 0;
-                            bool oizysWarning = PlayerHelper.IsInOizys() && OizysStandard == 0;
-                            bool auxesiaWarning = PlayerHelper.IsInAuxesia() && AuxesiaStandard == 0;
-
-                            if (sinusWarning || phaennaWarning || oizysWarning)
+                            var currentMoon = CosmicMoonRegistry.GetMoonForTerritory(Player.Territory.RowId);
+                            if (currentMoon != null)
                             {
-                                string tooltip = "Hey! You seem to not have any standardard missions enabled on the planet/moon you're currently on.\n" +
-                                    "Please make sure to do so for this job if you don't want it to stall out when there is no timed/weather missions.\n" +
-                                    "Currently enabled on the planet you're on:";
+                                var standardCount = CosmicMoonRegistry.CountEnabledStandardMissions(
+                                    currentMoon.TerritoryId, agendaInfo.SelectedJob);
 
+                                if (standardCount == 0)
+                                {
+                                    var tooltip = "Hey! You seem to not have any standardard missions enabled on the planet/moon you're currently on.\n" +
+                                        "Please make sure to do so for this job if you don't want it to stall out when there is no timed/weather missions.\n" +
+                                        $"Currently enabled on {currentMoon.DisplayName}: {standardCount}";
 
-                                if (PlayerHelper.IsInSinusArdorum())
-                                    tooltip += $"\nSinus = {SinusStandard}";
-                                else if (PlayerHelper.IsInPhaenna())
-                                    tooltip += $"\nPhaenna = {PhaennaStandard}";
-                                else if (PlayerHelper.IsInOizys())
-                                    tooltip += $"\nOizys = {OizysStandard}";
-                                else if (PlayerHelper.IsInAuxesia())
-                                    tooltip += $"\nAuxesia = {AuxesiaStandard}";
-
-                                ImGui.SameLine();
-                                ImGui.AlignTextToFramePadding();
-                                ImGui_Ice.IconWithTooltip(Dalamud.Interface.FontAwesomeIcon.ExclamationTriangle, tooltip, false);
+                                    ImGui.SameLine();
+                                    ImGui.AlignTextToFramePadding();
+                                    ImGui_Ice.IconWithTooltip(Dalamud.Interface.FontAwesomeIcon.ExclamationTriangle, tooltip, false);
+                                }
                             }
                         }
 
@@ -647,6 +613,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                             if (selectedOption is PlaylistOptions.SinusMax 
                                                or PlaylistOptions.PhaennaMax 
                                                or PlaylistOptions.OizysMax 
+                                               or PlaylistOptions.AuxesiaMax
                                                or PlaylistOptions.SelectedRelicLv 
                                                or PlaylistOptions.ToolMaxExp)
                             {
@@ -656,12 +623,9 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                                 current = MaxToolProgress(job);
                                 goal = selectedOption switch
                                 {
-                                    PlaylistOptions.SinusMax => 9,
-                                    PlaylistOptions.PhaennaMax => 14,
-                                    PlaylistOptions.OizysMax => 17,
                                     PlaylistOptions.ToolMaxExp => MaxToolProgress(job, false),
                                     PlaylistOptions.SelectedRelicLv => agendaInfo.SelectedRelicLevel,
-                                    _ => 20
+                                    _ => CosmicMoonRegistry.GetMaxRelicGoal(selectedOption),
                                 };
                             }
                             else if (selectedOption is PlaylistOptions.ClassLevel)

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Cosmic_Agenda.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Cosmic_Agenda.cs
@@ -14,23 +14,21 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
     {
         public static List<uint> JobOptions = new() { 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 };
 
-        public static List<PlaylistOptions> PlaylistOptionsOrder = new()
+        public static List<PlaylistOptions> PlaylistOptionsOrder { get; } = BuildPlaylistOptionsOrder();
+
+        private static List<PlaylistOptions> BuildPlaylistOptionsOrder()
         {
-            PlaylistOptions.None,
-            PlaylistOptions.SinusMax,
-            PlaylistOptions.PhaennaMax,
-            PlaylistOptions.OizysMax,
-            PlaylistOptions.AuxesiaMax,
-            PlaylistOptions.ToolMaxExp,
-            PlaylistOptions.SelectedRelicLv,
-
-            PlaylistOptions.CreditAmount,
-            PlaylistOptions.PlanetAmount,
-            PlaylistOptions.DronebitAmount,
-
-            PlaylistOptions.ClassLevel,
-            PlaylistOptions.GoldClassMissions,
-        };
+            var order = new List<PlaylistOptions> { PlaylistOptions.None };
+            order.AddRange(CosmicMoonRegistry.MaxRelicPlaylistOptions);
+            order.Add(PlaylistOptions.ToolMaxExp);
+            order.Add(PlaylistOptions.SelectedRelicLv);
+            order.Add(PlaylistOptions.CreditAmount);
+            order.Add(PlaylistOptions.PlanetAmount);
+            order.Add(PlaylistOptions.DronebitAmount);
+            order.Add(PlaylistOptions.ClassLevel);
+            order.Add(PlaylistOptions.GoldClassMissions);
+            return order;
+        }
 
         public static uint SelectedJob = 8;
         public static PlaylistOptions SelectedOption = PlaylistOptions.None;
@@ -125,7 +123,8 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                         if (ImGui.Button("Add to Cosmic Agenda"))
                         {
                             var mode = ModeSelect.Standard;
-                            if (SelectedOption is PlaylistOptions.SinusMax or PlaylistOptions.PhaennaMax or PlaylistOptions.OizysMax or PlaylistOptions.AuxesiaMax or PlaylistOptions.SelectedRelicLv)
+                            if (SelectedOption is PlaylistOptions.SelectedRelicLv
+                                || CosmicMoonRegistry.IsMaxRelicPlaylistGoal(SelectedOption))
                             {
                                 mode = ModeSelect.RelicMode;
                             }
@@ -610,12 +609,9 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                             var job = agendaInfo.SelectedJob;
                             var territory = Player.Territory.RowId;
 
-                            if (selectedOption is PlaylistOptions.SinusMax 
-                                               or PlaylistOptions.PhaennaMax 
-                                               or PlaylistOptions.OizysMax 
-                                               or PlaylistOptions.AuxesiaMax
-                                               or PlaylistOptions.SelectedRelicLv 
-                                               or PlaylistOptions.ToolMaxExp)
+                            if (CosmicMoonRegistry.IsMaxRelicPlaylistGoal(selectedOption)
+                                || selectedOption is PlaylistOptions.SelectedRelicLv
+                                || selectedOption is PlaylistOptions.ToolMaxExp)
                             {
                                 var ScoreInfo = CosmicHelper.Cosmic_ClassInfo();
 

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Cosmic_Agenda.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Cosmic_Agenda.cs
@@ -631,8 +631,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                             }
                             else if (selectedOption is PlaylistOptions.CreditAmount)
                             {
-                                uint cosmoCreditId = 45690;
-                                if (PlayerHelper.GetItemCount(cosmoCreditId, out var creditAmount))
+                                if (PlayerHelper.GetItemCount(CosmicHelper.CosmoCreditItemId, out var creditAmount))
                                 {
                                     current = creditAmount;
                                     goal = agendaInfo.CreditAmount;
@@ -640,7 +639,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                             }
                             else if (selectedOption is PlaylistOptions.PlanetAmount)
                             {
-                                if (CosmicHelper.PlanetCreditInfo.TryGetValue(territory, out var gambaCredits) && PlayerHelper.GetItemCount(gambaCredits, out var gambaAmount))
+                                if (CosmicMoonRegistry.TryGetPlanetCreditItemId(territory, out var gambaCredits) && PlayerHelper.GetItemCount(gambaCredits, out var gambaAmount))
                                 {
                                     current = gambaAmount;
                                     goal = agendaInfo.PlanetAmount;
@@ -648,7 +647,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                             }
                             else if (selectedOption is PlaylistOptions.DronebitAmount)
                             {
-                                if (CosmicHelper.DronebitInfo.TryGetValue(territory, out var dronebitAmount))
+                                if (CosmicMoonRegistry.TryGetDronebit(territory, out var dronebitAmount))
                                 {
                                     PlayerHelper.GetItemCount(dronebitAmount.creditId, out var count);
 

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Expedition_Log.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Expedition_Log.cs
@@ -743,8 +743,8 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                                     if (exp.Value.Current == exp.Value.Max)
                                         completedSubStages++;
                                 }
-                                // Use integer math, then convert once at the end
-                                currentExpStage = CosmicHelper.MaxRelicLevel + (completedSubStages / 10f);
+                                // Bar max is highest relic stage across all moons (20 on Auxesia; was hardcoded 17).
+                                currentExpStage = CosmicMoonRegistry.HighestMaxRelicStage + (completedSubStages / 10f);
                             }
 
                             ImGui.TableNextColumn();
@@ -763,7 +763,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                             float offsetY = (rowHeight - barHeight) / 2f;
                             ImGui.SetCursorScreenPos(new Vector2(cellMin.X, cellMin.Y + offsetY));
 
-                            ImGui_Ice.Draw_XPBar(currentExpStage, CosmicHelper.MaxRelicLevel, CosmicHelper.MaxRelicExpStatus, size: new Vector2(200, barHeight));
+                            ImGui_Ice.Draw_XPBar(currentExpStage, CosmicMoonRegistry.HighestMaxRelicStage, CosmicHelper.MaxRelicExpStatus, size: new Vector2(200, barHeight));
                             if (ImGui.IsItemHovered())
                             {
                                 ImGui.BeginTooltip();
@@ -788,6 +788,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
             }
             else
             {
+                var maxRelicStage = CosmicMoonRegistry.GetMaxRelicStage((uint)Svc.ClientState.TerritoryType);
                 var jobStatus = expInfo[SelectedJob];
                 if (ImGui.BeginTable("Specific Class Details", 2, ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.Borders))
                 {
@@ -822,12 +823,12 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
 
                     ImGui.TableNextRow();
                     ImGui.TableSetColumnIndex(0);
-                    ImGui_Ice.Table_FullCenterText($" {jobStatus.Stage_Current} / {CosmicHelper.MaxRelicLevel}");
+                    ImGui_Ice.Table_FullCenterText($" {jobStatus.Stage_Current} / {maxRelicStage}");
 
                     ImGui.TableNextColumn();
                     var LvCellMin = ImGui.GetCursorScreenPos();
                     ImGui.SetCursorScreenPos(new Vector2(LvCellMin.X, LvCellMin.Y + offsetY));
-                    ImGui_Ice.Draw_XPBar(jobStatus.Stage_Current, CosmicHelper.MaxRelicLevel, CosmicHelper.MaxRelicLevel);
+                    ImGui_Ice.Draw_XPBar(jobStatus.Stage_Current, maxRelicStage, maxRelicStage);
 
                     foreach (var exp in jobStatus.CurrentExp)
                     {

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Expedition_Log.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Expedition_Log.cs
@@ -25,7 +25,8 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
             Progress,
             Sinus,
             Phaenna,
-            Oizys
+            Oizys,
+            Auxesia,
         }
 
         private static ExpeditionTabs selectedTab = ExpeditionTabs.Progress;
@@ -94,6 +95,16 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
             [ExpeditionTabs.Sinus] = new(),
             [ExpeditionTabs.Phaenna] = new(),
             [ExpeditionTabs.Oizys] = new(),
+            [ExpeditionTabs.Auxesia] = new(),
+        };
+
+        private static ExpeditionTabs TabForMoon(CosmicMoonDefinition moon) => moon.TerritoryId switch
+        {
+            1237 => ExpeditionTabs.Sinus,
+            1291 => ExpeditionTabs.Phaenna,
+            1310 => ExpeditionTabs.Oizys,
+            1319 => ExpeditionTabs.Auxesia,
+            _ => ExpeditionTabs.Progress,
         };
         private static void ClassDetails()
         {
@@ -104,13 +115,6 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
 
             if (ImGui.BeginChild("##Expedition_TabScroll", new(0, buttonRowHeight), false, ImGuiWindowFlags.HorizontalScrollbar))
             {
-                var moons = new (string Name, string Asset, ExpeditionTabs type, uint Territory)[]
-                {
-                    ("Sinus Ardorum", "ICE.Resources.Sinus_Ardorum.png", ExpeditionTabs.Sinus, 1237),
-                    ("Phaenna", "ICE.Resources.Phaenna.png", ExpeditionTabs.Phaenna, 1291),
-                    ("Oizys", "ICE.Resources.Oizys.png", ExpeditionTabs.Oizys, 1310),
-                };
-
                 if (SelectedJob != 0)
                 {
                     var classIcon = CosmicHelper.ClassInfoDict[SelectedJob];
@@ -121,14 +125,19 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                     var allClassTexture = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), "ICE.Resources.CosmicClassTracker.png").GetWrapOrEmpty();
                     DrawImageTabButton("All Class progresses", ExpeditionTabs.Progress, ref selectedTab, allClassTexture);
                 }
-                foreach (var moon in moons)
+
+                foreach (var moon in CosmicMoonRegistry.All)
                 {
+                    var tab = TabForMoon(moon);
+                    if (tab == ExpeditionTabs.Progress)
+                        continue;
+
                     List<uint> missions = new();
                     uint completed = 0;
 
                     if (SelectedJob != 0)
                     {
-                        foreach (var mission in CosmicHelper.SheetMissionDict.Where(x => x.Value.Jobs.Contains(SelectedJob)).Where(x => x.Value.TerritoryId == moon.Territory))
+                        foreach (var mission in CosmicHelper.SheetMissionDict.Where(x => x.Value.Jobs.Contains(SelectedJob)).Where(x => x.Value.TerritoryId == moon.TerritoryId))
                         {
                             missions.Add(mission.Key);
                             if (mission.Value.CompletionStatus is CosmicHelper.Status.Gold)
@@ -137,7 +146,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                     }
                     else
                     {
-                        foreach (var mission in CosmicHelper.SheetMissionDict.Where(x => x.Value.TerritoryId == moon.Territory))
+                        foreach (var mission in CosmicHelper.SheetMissionDict.Where(x => x.Value.TerritoryId == moon.TerritoryId))
                         {
                             missions.Add(mission.Key);
                             if (mission.Value.CompletionStatus is CosmicHelper.Status.Gold)
@@ -145,11 +154,11 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                         }
                     }
 
-                    MissionList[moon.type] = missions;
+                    MissionList[tab] = missions;
 
-                    var texture = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), moon.Asset).GetWrapOrEmpty();
+                    var texture = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), moon.IconResource).GetWrapOrEmpty();
                     ImGui.SameLine();
-                    DrawImageTabButton($"{moon.Name} [{completed} / {missions.Count()}]", moon.type, ref selectedTab, texture);
+                    DrawImageTabButton($"{moon.DisplayName} [{completed} / {missions.Count()}]", tab, ref selectedTab, texture);
                 }
                 ImGui_Ice.EndCategoryButtonRow();
             }
@@ -163,7 +172,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                 }
                 ImGui.EndChild();
             }
-            else if (selectedTab is ExpeditionTabs.Sinus or ExpeditionTabs.Phaenna or ExpeditionTabs.Oizys)
+            else if (selectedTab is ExpeditionTabs.Sinus or ExpeditionTabs.Phaenna or ExpeditionTabs.Oizys or ExpeditionTabs.Auxesia)
             {
                 ImGui.Checkbox("Hide Completed", ref HideCompleted);
                 if (ImGui.BeginChild("Mission Completion Status Window", ImGui.GetContentRegionAvail()))
@@ -928,21 +937,18 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
 
             if (SelectedJob == 0)
             {
-                var researchTypes = new (string Name, string Asset, int MaxLv)[]
-                {
-                    ("Sinus", "ICE.Resources.ResearchIcons.novice.png", 9),
-                    ("Phaenna", "ICE.Resources.ResearchIcons.intermediate.png", 14),
-                    ("Oizys", "ICE.Resources.ResearchIcons.advance.png", 17),
-                };
+                var researchTypes = CosmicMoonRegistry.All
+                    .Where(m => m.ResearchIconResource != null)
+                    .Select(m => (Name: m.DisplayName, Asset: m.ResearchIconResource!, MaxRelicStage: m.MaxRelicStage))
+                    .ToArray();
 
-                if (ImGui.BeginTable("Class Progress: Icon Preview", 3, ImGuiTableFlags.SizingFixedFit))
+                if (ImGui.BeginTable("Class Progress: Icon Preview", researchTypes.Length, ImGuiTableFlags.SizingFixedFit))
                 {
-                    ImGui.TableSetupColumn("Sinus");
-                    ImGui.TableSetupColumn("Phaenna");
-                    ImGui.TableSetupColumn("Oizys");
+                    for (int i = 0; i < researchTypes.Length; i++)
+                        ImGui.TableSetupColumn(researchTypes[i].Name);
 
                     ImGui.TableNextRow();
-                    for (int i = 0; i < researchTypes.Count(); i++)
+                    for (int i = 0; i < researchTypes.Length; i++)
                     {
                         var type = researchTypes[i];
                         var icon = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), type.Asset).GetWrapOrEmpty();
@@ -951,11 +957,11 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                     }
 
                     ImGui.TableNextRow();
-                    for (int i = 0; i < researchTypes.Count(); i++)
+                    for (int i = 0; i < researchTypes.Length; i++)
                     {
                         var type = researchTypes[i];
                         ImGui.TableSetColumnIndex(i);
-                        var count = expInfo.Where(x => x.Value.Stage_Current >= type.MaxLv).Count();
+                        var count = expInfo.Where(x => x.Value.Stage_Current >= type.MaxRelicStage).Count();
                         ImGui_Ice.Table_FullCenterText($"{count}/11");
                     }
 

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Expedition_Log.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Expedition_Log.cs
@@ -10,6 +10,7 @@ using ICE.Utilities.Cosmic_Helper;
 using ICE.Utilities.GatheringHelper;
 using ICE.Utilities.ImGuiTools;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using static ECommons.UIHelpers.AddonMasterImplementations.AddonMaster;
 
@@ -20,16 +21,9 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
 
         private static uint SelectedJob = 8;
 
-        public enum ExpeditionTabs
-        {
-            Progress,
-            Sinus,
-            Phaenna,
-            Oizys,
-            Auxesia,
-        }
+        private const uint ProgressTabId = 0;
 
-        private static ExpeditionTabs selectedTab = ExpeditionTabs.Progress;
+        private static uint selectedTabId = ProgressTabId;
         private static bool HideCompleted = false;
 
         public static void Draw()
@@ -90,22 +84,10 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                 ImGui.EndTable();
             }
         }
-        private static Dictionary<ExpeditionTabs, List<uint>> MissionList = new()
-        {
-            [ExpeditionTabs.Sinus] = new(),
-            [ExpeditionTabs.Phaenna] = new(),
-            [ExpeditionTabs.Oizys] = new(),
-            [ExpeditionTabs.Auxesia] = new(),
-        };
+        private static Dictionary<uint, List<uint>> MissionList = CosmicMoonRegistry.All
+            .ToDictionary(m => m.TerritoryId, _ => new List<uint>());
 
-        private static ExpeditionTabs TabForMoon(CosmicMoonDefinition moon) => moon.TerritoryId switch
-        {
-            1237 => ExpeditionTabs.Sinus,
-            1291 => ExpeditionTabs.Phaenna,
-            1310 => ExpeditionTabs.Oizys,
-            1319 => ExpeditionTabs.Auxesia,
-            _ => ExpeditionTabs.Progress,
-        };
+        private static uint TabIdForMoon(CosmicMoonDefinition moon) => moon.TerritoryId;
         private static void ClassDetails()
         {
             float scale = ImGuiHelpers.GlobalScale;
@@ -118,18 +100,18 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                 if (SelectedJob != 0)
                 {
                     var classIcon = CosmicHelper.ClassInfoDict[SelectedJob];
-                    DrawImageTabButton("Class Progress", ExpeditionTabs.Progress, ref selectedTab, classIcon.JobIcon.GetWrapOrEmpty());
+                    DrawImageTabButton("Class Progress", ProgressTabId, ref selectedTabId, classIcon.JobIcon.GetWrapOrEmpty());
                 }
                 else
                 {
                     var allClassTexture = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), "ICE.Resources.CosmicClassTracker.png").GetWrapOrEmpty();
-                    DrawImageTabButton("All Class progresses", ExpeditionTabs.Progress, ref selectedTab, allClassTexture);
+                    DrawImageTabButton("All Class progresses", ProgressTabId, ref selectedTabId, allClassTexture);
                 }
 
-                foreach (var moon in CosmicMoonRegistry.All)
+                foreach (var moon in CosmicMoonRegistry.All.OrderBy(m => m.ExpeditionTabIndex))
                 {
-                    var tab = TabForMoon(moon);
-                    if (tab == ExpeditionTabs.Progress)
+                    var tabId = TabIdForMoon(moon);
+                    if (tabId == ProgressTabId)
                         continue;
 
                     List<uint> missions = new();
@@ -154,17 +136,17 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                         }
                     }
 
-                    MissionList[tab] = missions;
+                    MissionList[tabId] = missions;
 
                     var texture = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), moon.IconResource).GetWrapOrEmpty();
                     ImGui.SameLine();
-                    DrawImageTabButton($"{moon.DisplayName} [{completed} / {missions.Count()}]", tab, ref selectedTab, texture);
+                    DrawImageTabButton($"{moon.DisplayName} [{completed} / {missions.Count()}]", tabId, ref selectedTabId, texture);
                 }
                 ImGui_Ice.EndCategoryButtonRow();
             }
             ImGui.EndChild();
 
-            if (selectedTab is ExpeditionTabs.Progress)
+            if (selectedTabId == ProgressTabId)
             {
                 if (ImGui.BeginChild("Class Progress"))
                 {
@@ -172,17 +154,17 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                 }
                 ImGui.EndChild();
             }
-            else if (selectedTab is ExpeditionTabs.Sinus or ExpeditionTabs.Phaenna or ExpeditionTabs.Oizys or ExpeditionTabs.Auxesia)
+            else if (MissionList.TryGetValue(selectedTabId, out var missions))
             {
                 ImGui.Checkbox("Hide Completed", ref HideCompleted);
                 if (ImGui.BeginChild("Mission Completion Status Window", ImGui.GetContentRegionAvail()))
                 {
-                    MissionTable(MissionList[selectedTab]);
+                    MissionTable(missions);
                 }
                 ImGui.EndChild();
             }
         }
-        public static bool DrawImageTabButton(string label, ExpeditionTabs tab, ref ExpeditionTabs selectedTab, IDalamudTextureWrap? image = null, float spacingAfter = 5, bool disabled = false, Vector2? uv0 = null, Vector2? uv1 = null)
+        public static bool DrawImageTabButton(string label, uint tabId, ref uint selectedTabId, IDalamudTextureWrap? image = null, float spacingAfter = 5, bool disabled = false, Vector2? uv0 = null, Vector2? uv1 = null)
         {
             float scale = ImGuiHelpers.GlobalScale;
 
@@ -200,7 +182,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
             float contentWidth = horizontalPadding * 2 + imageWidth + textSize.X;
             float contentHeight = verticalPadding * 2 + textSize.Y;
 
-            bool isSelected = selectedTab == tab;
+            bool isSelected = selectedTabId == tabId;
 
             var buttonRect = new Vector2(cursorPos.X + contentWidth, cursorPos.Y + contentHeight);
             bool isHovered = !disabled && ImGui.IsMouseHoveringRect(cursorPos, buttonRect)
@@ -208,7 +190,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
             bool isClicked = isHovered && ImGui.IsMouseClicked(ImGuiMouseButton.Left);
 
             if (isClicked && !disabled)
-                selectedTab = tab;
+                selectedTabId = tabId;
 
             var bgColor = ImGui_Ice.GetButtonColor(isSelected, isHovered, disabled);
             var textColor = disabled
@@ -236,7 +218,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
             ImGui.PopStyleColor();
 
             ImGui.SetCursorScreenPos(cursorPos);
-            ImGui.InvisibleButton($"##{tab}_btn", new Vector2(contentWidth, contentHeight));
+            ImGui.InvisibleButton($"##{tabId}_btn", new Vector2(contentWidth, contentHeight));
             ImGui.SameLine(0, spacingAfter * scale);
 
             return isSelected;

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Expedition_Log.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Expedition_Log.cs
@@ -408,284 +408,45 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                             var spacing = ImGui.GetStyle().ItemSpacing.X;
                             var totalWidth = (buttonSize.X * 3) + (spacing * 2);
 
-                            // Center the group
                             var cursorPosX = ImGui.GetCursorPosX();
                             var availWidth = ImGui.GetContentRegionAvail().X;
                             ImGui.SetCursorPosX(cursorPosX + (availWidth - totalWidth) * 0.5f);
 
-                            // Gold
-                            ImGui.PushStyleColor(ImGuiCol.Text, missionConfig.TurninGoal == TurninState.Gold ? GoldColor : DisabledColor);
-                            if (ImGuiEx.IconButton(FontAwesomeIcon.Trophy, "##Gold", buttonSize))
+                            var turninGoal = missionConfig.TurninGoal;
+                            var goldEnabled = turninGoal >= TurninState.Gold;
+                            var silverEnabled = turninGoal >= TurninState.Silver;
+                            var bronzeEnabled = turninGoal >= TurninState.Bronze;
+
+                            void DrawTurninButton(string id, TurninState state, bool enabled, Vector4 color, string tooltipLabel)
                             {
-                                // If AutoTurnin is on, we're enabling individual controls
-                                if (missionConfig.AutoTurnin)
+                                ImGui.PushStyleColor(ImGuiCol.Text, enabled ? color : DisabledColor);
+                                if (ImGuiEx.IconButton(FontAwesomeIcon.Trophy, id, buttonSize))
                                 {
-                                    missionConfig.AutoTurnin = false;
-                                    missionConfig.TurninGold = false;  // Turn off gold
-                                    missionConfig.TurninSilver = true; // Keep others on
-                                    missionConfig.TurninBronze = true;
+                                    missionConfig.TurninGoal = state;
+                                    C.SaveDebounced();
                                 }
-                                else
+                                if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
                                 {
-                                    // Toggle the button
-                                    missionConfig.TurninGold = !missionConfig.TurninGold;
-
-                                    // Check the new state
-                                    if (missionConfig.TurninGold && missionConfig.TurninSilver && missionConfig.TurninBronze)
-                                    {
-                                        // All three enabled -> AutoTurnin mode
-                                        missionConfig.AutoTurnin = true;
-                                        missionConfig.TurninGold = false;
-                                        missionConfig.TurninSilver = false;
-                                        missionConfig.TurninBronze = false;
-                                    }
-                                    else if (!missionConfig.TurninGold && !missionConfig.TurninSilver && !missionConfig.TurninBronze)
-                                    {
-                                        // All three disabled -> AutoTurnin mode (don't disable any)
-                                        missionConfig.AutoTurnin = true;
-                                    }
+                                    missionConfig.TurninGoal = state;
+                                    C.SaveDebounced();
                                 }
-
-                                C.SaveDebounced();
-                            }
-                            // Right-click to enable only this one
-                            if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
-                            {
-                                missionConfig.AutoTurnin = false;
-                                missionConfig.TurninGold = true;
-                                missionConfig.TurninSilver = false;
-                                missionConfig.TurninBronze = false;
-                                C.SaveDebounced();
-                            }
-                            ImGui.PopStyleColor();
-                            if (ImGui.IsItemHovered())
-                            {
-                                ImGui.BeginTooltip();
-
-                                if (missionConfig.AutoTurnin)
+                                ImGui.PopStyleColor();
+                                if (ImGui.IsItemHovered())
                                 {
-                                    ImGuiEx.Icon(GoldColor, FontAwesomeIcon.Trophy);
+                                    ImGui.BeginTooltip();
+                                    ImGuiEx.Icon(color, FontAwesomeIcon.Trophy);
                                     ImGui.SameLine();
-                                    ImGui.Text("Gold Enabled");
-
-                                    ImGuiEx.Icon(SilverColor, FontAwesomeIcon.Trophy);
-                                    ImGui.SameLine();
-                                    ImGui.Text("Silver Enabled");
-
-                                    ImGuiEx.Icon(BronzeColor, FontAwesomeIcon.Trophy);
-                                    ImGui.SameLine();
-                                    ImGui.Text("Bronze Enabled");
+                                    ImGui.Text($"{tooltipLabel} — turn in at {state.ToString().ToLower()} or better");
+                                    ImGui.Text($"Right click to set minimum turnin to {state.ToString().ToLower()}");
+                                    ImGui.EndTooltip();
                                 }
-                                else
-                                {
-                                    if (missionConfig.TurninGold)
-                                    {
-                                        ImGuiEx.Icon(GoldColor, FontAwesomeIcon.Trophy);
-                                        ImGui.SameLine();
-                                        ImGui.Text("Gold Enabled");
-                                    }
-                                    if (missionConfig.TurninSilver)
-                                    {
-                                        ImGuiEx.Icon(SilverColor, FontAwesomeIcon.Trophy);
-                                        ImGui.SameLine();
-                                        ImGui.Text("Silver Enabled");
-                                    }
-                                    if (missionConfig.TurninBronze)
-                                    {
-                                        ImGuiEx.Icon(BronzeColor, FontAwesomeIcon.Trophy);
-                                        ImGui.SameLine();
-                                        ImGui.Text("Bronze Enabled");
-                                    }
-                                }
-
-                                ImGui.Text("Right click to only enable gold");
-
-                                ImGui.EndTooltip();
                             }
 
+                            DrawTurninButton("##Gold", TurninState.Gold, goldEnabled, GoldColor, "Gold");
                             ImGui.SameLine();
-
-                            // Silver
-                            ImGui.PushStyleColor(ImGuiCol.Text, missionConfig.TurninSilver || missionConfig.AutoTurnin ? SilverColor : DisabledColor);
-                            if (ImGuiEx.IconButton(FontAwesomeIcon.Trophy, "##Silver", buttonSize))
-                            {
-                                // If AutoTurnin is on, we're enabling individual controls
-                                if (missionConfig.AutoTurnin)
-                                {
-                                    missionConfig.AutoTurnin = false;
-                                    missionConfig.TurninGold = true;
-                                    missionConfig.TurninSilver = false;  // Turn off silver
-                                    missionConfig.TurninBronze = true;
-                                }
-                                else
-                                {
-                                    // Toggle the button
-                                    missionConfig.TurninSilver = !missionConfig.TurninSilver;
-
-                                    // Check the new state
-                                    if (missionConfig.TurninGold && missionConfig.TurninSilver && missionConfig.TurninBronze)
-                                    {
-                                        // All three enabled -> AutoTurnin mode
-                                        missionConfig.AutoTurnin = true;
-                                        missionConfig.TurninGold = false;
-                                        missionConfig.TurninSilver = false;
-                                        missionConfig.TurninBronze = false;
-                                    }
-                                    else if (!missionConfig.TurninGold && !missionConfig.TurninSilver && !missionConfig.TurninBronze)
-                                    {
-                                        // All three disabled -> AutoTurnin mode (don't disable any)
-                                        missionConfig.AutoTurnin = true;
-                                    }
-                                }
-
-                                C.SaveDebounced();
-                            }
-                            // Right-click to enable only this one
-                            if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
-                            {
-                                missionConfig.AutoTurnin = false;
-                                missionConfig.TurninGold = false;
-                                missionConfig.TurninSilver = true;
-                                missionConfig.TurninBronze = false;
-                                C.SaveDebounced();
-                            }
-                            ImGui.PopStyleColor();
-                            if (ImGui.IsItemHovered())
-                            {
-                                ImGui.BeginTooltip();
-
-                                if (missionConfig.AutoTurnin)
-                                {
-                                    ImGuiEx.Icon(GoldColor, FontAwesomeIcon.Trophy);
-                                    ImGui.SameLine();
-                                    ImGui.Text("Gold Enabled");
-
-                                    ImGuiEx.Icon(SilverColor, FontAwesomeIcon.Trophy);
-                                    ImGui.SameLine();
-                                    ImGui.Text("Silver Enabled");
-
-                                    ImGuiEx.Icon(BronzeColor, FontAwesomeIcon.Trophy);
-                                    ImGui.SameLine();
-                                    ImGui.Text("Bronze Enabled");
-                                }
-                                else
-                                {
-                                    if (missionConfig.TurninGold)
-                                    {
-                                        ImGuiEx.Icon(GoldColor, FontAwesomeIcon.Trophy);
-                                        ImGui.SameLine();
-                                        ImGui.Text("Gold Enabled");
-                                    }
-                                    if (missionConfig.TurninSilver)
-                                    {
-                                        ImGuiEx.Icon(SilverColor, FontAwesomeIcon.Trophy);
-                                        ImGui.SameLine();
-                                        ImGui.Text("Silver Enabled");
-                                    }
-                                    if (missionConfig.TurninBronze)
-                                    {
-                                        ImGuiEx.Icon(BronzeColor, FontAwesomeIcon.Trophy);
-                                        ImGui.SameLine();
-                                        ImGui.Text("Bronze Enabled");
-                                    }
-                                }
-
-                                ImGui.Text("Right click to only enable silver");
-
-                                ImGui.EndTooltip();
-                            }
-
+                            DrawTurninButton("##Silver", TurninState.Silver, silverEnabled, SilverColor, "Silver");
                             ImGui.SameLine();
-
-                            // Bronze
-                            ImGui.PushStyleColor(ImGuiCol.Text, missionConfig.TurninBronze || missionConfig.AutoTurnin ? BronzeColor : DisabledColor);
-                            if (ImGuiEx.IconButton(FontAwesomeIcon.Trophy, "##Bronze", buttonSize))
-                            {
-                                // If AutoTurnin is on, we're enabling individual controls
-                                if (missionConfig.AutoTurnin)
-                                {
-                                    missionConfig.AutoTurnin = false;
-                                    missionConfig.TurninGold = true;
-                                    missionConfig.TurninSilver = true;
-                                    missionConfig.TurninBronze = false;  // Turn off bronze
-                                }
-                                else
-                                {
-                                    // Toggle the button
-                                    missionConfig.TurninBronze = !missionConfig.TurninBronze;
-
-                                    // Check the new state
-                                    if (missionConfig.TurninGold && missionConfig.TurninSilver && missionConfig.TurninBronze)
-                                    {
-                                        // All three enabled -> AutoTurnin mode
-                                        missionConfig.AutoTurnin = true;
-                                        missionConfig.TurninGold = false;
-                                        missionConfig.TurninSilver = false;
-                                        missionConfig.TurninBronze = false;
-                                    }
-                                    else if (!missionConfig.TurninGold && !missionConfig.TurninSilver && !missionConfig.TurninBronze)
-                                    {
-                                        // All three disabled -> AutoTurnin mode (don't disable any)
-                                        missionConfig.AutoTurnin = true;
-                                    }
-                                }
-
-                                C.SaveDebounced();
-                            }
-                            // Right-click to enable only this one
-                            if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
-                            {
-                                missionConfig.AutoTurnin = false;
-                                missionConfig.TurninGold = false;
-                                missionConfig.TurninSilver = false;
-                                missionConfig.TurninBronze = true;
-                                C.SaveDebounced();
-                            }
-                            ImGui.PopStyleColor();
-                            if (ImGui.IsItemHovered())
-                            {
-                                ImGui.BeginTooltip();
-
-                                if (missionConfig.AutoTurnin)
-                                {
-                                    ImGuiEx.Icon(GoldColor, FontAwesomeIcon.Trophy);
-                                    ImGui.SameLine();
-                                    ImGui.Text("Gold Enabled");
-
-                                    ImGuiEx.Icon(SilverColor, FontAwesomeIcon.Trophy);
-                                    ImGui.SameLine();
-                                    ImGui.Text("Silver Enabled");
-
-                                    ImGuiEx.Icon(BronzeColor, FontAwesomeIcon.Trophy);
-                                    ImGui.SameLine();
-                                    ImGui.Text("Bronze Enabled");
-                                }
-                                else
-                                {
-                                    if (missionConfig.TurninGold)
-                                    {
-                                        ImGuiEx.Icon(GoldColor, FontAwesomeIcon.Trophy);
-                                        ImGui.SameLine();
-                                        ImGui.Text("Gold Enabled");
-                                    }
-                                    if (missionConfig.TurninSilver)
-                                    {
-                                        ImGuiEx.Icon(SilverColor, FontAwesomeIcon.Trophy);
-                                        ImGui.SameLine();
-                                        ImGui.Text("Silver Enabled");
-                                    }
-                                    if (missionConfig.TurninBronze)
-                                    {
-                                        ImGuiEx.Icon(BronzeColor, FontAwesomeIcon.Trophy);
-                                        ImGui.SameLine();
-                                        ImGui.Text("Bronze Enabled");
-                                    }
-                                }
-
-                                ImGui.Text("Right click to only enable bronze");
-
-                                ImGui.EndTooltip();
-                            }
+                            DrawTurninButton("##Bronze", TurninState.Bronze, bronzeEnabled, BronzeColor, "Bronze");
                         }
 
                         ImGui.TableNextColumn();

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Mission_Setup.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Mission_Setup.cs
@@ -158,9 +158,11 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                 ImGui.SetCursorPosY(ImGui.GetCursorPosY() + yOffset);
 
                 bool unsupportedArtisan = false; // xpLeveling && CosmicHelper.CrafterJobList.Contains((uint)Player.Job);
-                bool unsupportedMoon = false; // PlayerHelper.IsInOizys() && xpLeveling;
+                bool unsupportedMoon = xpLeveling
+                    && CosmicMoonRegistry.TryGetMoon(Player.Territory.RowId, out var currentMoon)
+                    && !CosmicMoonRegistry.HasLevelingContent(currentMoon);
 
-                // TODO: Make sure to disable new moon for leveling / gathering. . . 
+                // Leveling / gathering on a hub requires QuickLevelList + route YAML — Auxesia pending content
                 using (ImRaii.Disabled(SchedulerMain.State != IceState.Idle || !usingSupportedJob || unsupportedMoon))
                 {
                     if (ImGui.Button("Start", new Vector2(150 * scale, 0)))
@@ -190,8 +192,8 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                     if (ImGui.IsItemHovered())
                     {
                         ImGui.BeginTooltip();
-                        ImGui.Text("Hey! This moon is currently not supported for leveling yet. (It's also worse than sinus or phaenna)");
-                        ImGui.Text("Please wait till I get the time to focus on this");
+                        ImGui.Text("Hey! This moon is currently not supported for leveling yet.");
+                        ImGui.Text("QuickLevelList and gathering routes are still being authored for this hub.");
                         ImGui.EndTooltip();
                     }
                 }

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Mission_Setup.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Mission_Setup.cs
@@ -162,7 +162,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                     && CosmicMoonRegistry.TryGetMoon(Player.Territory.RowId, out var currentMoon)
                     && !CosmicMoonRegistry.HasLevelingContent(currentMoon);
 
-                // Leveling / gathering on a hub requires QuickLevelList + route YAML — Auxesia pending content
+                // Leveling on a hub requires QuickLevelList entries; gathering still needs route YAML per territory
                 using (ImRaii.Disabled(SchedulerMain.State != IceState.Idle || !usingSupportedJob || unsupportedMoon))
                 {
                     if (ImGui.Button("Start", new Vector2(150 * scale, 0)))
@@ -184,7 +184,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                         ImGui.EndTooltip();
                     }
                 }
-                else if (unsupportedMoon)
+                else if (unsupportedMoon && CosmicMoonRegistry.TryGetMoon(Player.Territory.RowId, out var unsupportedHub))
                 {
                     ImGui.SameLine(0, 10 * scale);
                     ImGui.SetCursorPosY(ImGui.GetCursorPosY() + yOffset);
@@ -192,8 +192,14 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                     if (ImGui.IsItemHovered())
                     {
                         ImGui.BeginTooltip();
-                        ImGui.Text("Hey! This moon is currently not supported for leveling yet.");
-                        ImGui.Text("QuickLevelList and gathering routes are still being authored for this hub.");
+                        ImGui.Text($"Hey! {unsupportedHub.DisplayName} is not supported for leveling yet.");
+                        var missing = new List<string>();
+                        if (!CosmicMoonRegistry.HasLevelingContent(unsupportedHub))
+                            missing.Add("QuickLevelList missions");
+                        if (!CosmicMoonContent.HasGatheringRoutes(unsupportedHub.TerritoryId))
+                            missing.Add("gathering routes");
+                        if (missing.Count > 0)
+                            ImGui.Text($"Still needed: {string.Join(", ", missing)}.");
                         ImGui.EndTooltip();
                     }
                 }

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Mission_Setup.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Mission_Setup.cs
@@ -45,7 +45,6 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
             { "Red Mage", 35 },
             { "Pictomancer", 42 }
         };
-        private static string newListName = "";
 
         public static Mission_Table? MissionTable;
         private static List<CosmicHelper.MissionInfo> TableItems = [];

--- a/ICE/Ui/MainUi/SelectableSidebar.cs
+++ b/ICE/Ui/MainUi/SelectableSidebar.cs
@@ -218,7 +218,7 @@ namespace ICE.Ui.MainUi
 
             // When you land on a hub, auto-select only that moon in the mission filter
             var moonFlags = CosmicMoonRegistry.All
-                .Select(m => ((Func<bool>)(() => PlayerHelper.IsInZone(m.TerritoryId)), m.PlanetFilter))
+                .Select(m => ((Func<bool>)(() => Player.Territory.RowId == m.TerritoryId), m.PlanetFilter))
                 .ToArray();
 
             var planetFlags = CosmicMoonRegistry.All.Aggregate(ItemFilter.NoItems, (flags, m) => flags | m.PlanetFilter);

--- a/ICE/Ui/MainUi/SelectableSidebar.cs
+++ b/ICE/Ui/MainUi/SelectableSidebar.cs
@@ -7,6 +7,7 @@ using ICE.Ui.MainUi.ModeSelect_Modes.CosmicTable;
 using ICE.Utilities.Cosmic_Helper;
 using ICE.Utilities.ImGuiTools;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using TerraFX.Interop.Windows;
 
@@ -66,27 +67,20 @@ namespace ICE.Ui.MainUi
 
                     ImGui.SetCursorPosX(ImGui.GetCursorPosX() + leftOffset);
 
-                    var moons = new (string Name, string Asset, ItemFilter planetFilter)[]
-                    {
-                            ("Sinus Ardorum", "ICE.Resources.Sinus_Ardorum.png", ItemFilter.Sinus),
-                            ("Phaenna", "ICE.Resources.Phaenna.png", ItemFilter.Phaenna),
-                            ("Oizys", "ICE.Resources.Oizys.png", ItemFilter.Oizys), 
-                            ("Auxesia", "ICE.Resources.Auxesia.png", ItemFilter.Auxesia)
-                    };
-
-                    for (int i = 0; i < moons.Length; i++)
+                    // Moon list driven by CosmicMoonRegistry — add a moon there instead of copying IDs here
+                    for (int i = 0; i < CosmicMoonRegistry.All.Length; i++)
                     {
                         if (i > 0) ImGui.SameLine(0, iconSpacing);
 
-                        var moon = moons[i];
-                        bool isEnabled = C.ItemFilter.HasFlag(moon.planetFilter);
-                        var texture = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), moon.Asset).GetWrapOrEmpty();
+                        var moon = CosmicMoonRegistry.All[i];
+                        bool isEnabled = C.ItemFilter.HasFlag(moon.PlanetFilter);
+                        var texture = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), moon.IconResource).GetWrapOrEmpty();
 
                         if (ImGui_Ice.DrawStyledImageButton(texture, new Vector2(iconSize, iconSize), isEnabled))
                         {
                             C.ItemFilter = isEnabled
-                                ? C.ItemFilter & ~moon.planetFilter  // was on → turn off 
-                                : C.ItemFilter | moon.planetFilter;  // was off → turn on
+                                ? C.ItemFilter & ~moon.PlanetFilter  // was on → turn off 
+                                : C.ItemFilter | moon.PlanetFilter;  // was off → turn on
                             C.AutoSelectMoon = false;
                             if (Mission_Setup.MissionTable != null)
                                 Mission_Setup.MissionTable.SetFilterDirty();
@@ -96,7 +90,7 @@ namespace ICE.Ui.MainUi
 
                         if (ImGui.IsItemHovered())
                         {
-                            ImGui.SetTooltip(moon.Name);
+                            ImGui.SetTooltip(moon.DisplayName);
                         }
                     }
                 }
@@ -210,15 +204,12 @@ namespace ICE.Ui.MainUi
         {
             if (!autoSelectMoon) return;
 
-            var moonFlags = new (Func<bool> IsInZone, ItemFilter Flag)[]
-            {
-                (PlayerHelper.IsInSinusArdorum, ItemFilter.Sinus),
-                (PlayerHelper.IsInPhaenna,      ItemFilter.Phaenna),
-                (PlayerHelper.IsInOizys,        ItemFilter.Oizys),
-                (PlayerHelper.IsInAuxesia,      ItemFilter.Auxesia)
-            };
+            // When you land on a hub, auto-select only that moon in the mission filter
+            var moonFlags = CosmicMoonRegistry.All
+                .Select(m => ((Func<bool>)(() => PlayerHelper.IsInZone(m.TerritoryId)), m.PlanetFilter))
+                .ToArray();
 
-            var planetFlags = ItemFilter.Sinus | ItemFilter.Phaenna | ItemFilter.Oizys | ItemFilter.Auxesia;
+            var planetFlags = CosmicMoonRegistry.All.Aggregate(ItemFilter.NoItems, (flags, m) => flags | m.PlanetFilter);
 
             foreach (var (IsInZone, Flag) in moonFlags)
             {

--- a/ICE/Ui/MainUi/SelectableSidebar.cs
+++ b/ICE/Ui/MainUi/SelectableSidebar.cs
@@ -4,6 +4,7 @@ using Dalamud.Interface.Utility.Raii;
 using ECommons.GameHelpers;
 using ICE.Ui.MainUi.ModeSelect_Modes;
 using ICE.Ui.MainUi.ModeSelect_Modes.CosmicTable;
+using ICE.Utilities;
 using ICE.Utilities.Cosmic_Helper;
 using ICE.Utilities.ImGuiTools;
 using System.Collections.Generic;
@@ -98,7 +99,9 @@ namespace ICE.Ui.MainUi
                 {
                     ImGui_Ice.DrawSelectable_Image(65112, "Credit Shopping", WindowSelection.CreditShopping);
                     ImGui_Ice.DrawSelectable_Image(65127, "Gambling Settings", WindowSelection.GambaShopping);
-                    ImGui_Ice.DrawSelectable_Image(65138, "Dronebit Settings", WindowSelection.DroneShopping);
+
+                    if (ShowDronebitSettings())
+                        ImGui_Ice.DrawSelectable_Image(65138, "Dronebit Settings", WindowSelection.DroneShopping);
                 }
                 if (ImGui_Ice.Sidebar_CollaspableHeader("Settings", SidebarTabs.Settings, icon: FontAwesomeIcon.Cog))
                 {
@@ -161,6 +164,15 @@ namespace ICE.Ui.MainUi
 #endif
             }
         }
+        private static bool ShowDronebitSettings()
+        {
+            if (!PlayerHelper.IsInCosmicZone())
+                return true;
+
+            return CosmicMoonRegistry.TryGetMoon((uint)Svc.ClientState.TerritoryType, out var moon)
+                && moon.HasCosmodrome;
+        }
+
         private static void PluginIcon()
         {
             string PluginIcon = "ICE.Resources.Icon.png";

--- a/ICE/Ui/MainUi/Settings/DebugTab.cs
+++ b/ICE/Ui/MainUi/Settings/DebugTab.cs
@@ -1,4 +1,8 @@
 ﻿using Dalamud.Interface.Utility.Raii;
+using ECommons.GameHelpers;
+using ICE.Scheduler.Handlers;
+using ICE.Utilities;
+using ICE.Utilities.Cosmic_Helper;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,14 +18,19 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
             ImGui.Checkbox("Force OOM Main", ref SchedulerMain.DebugOOMMain);
             ImGui.Checkbox("Force OOM Sub", ref SchedulerMain.DebugOOMSub);
 
-            if (ImGui.Button("Get Sinus Forecast"))
+            if (ImGui.Button("Get current hub forecast"))
             {
-                List<WeatherForecast> forecast = WeatherForecastHandler.GetTerritoryForecast(1237);
+                // Same fallback as other debug tabs: current hub, or Sinus when not in cosmic.
+                var territoryId = PlayerHelper.IsInCosmicZone()
+                    ? Player.Territory.RowId
+                    : CosmicMoonRegistry.Sinus.TerritoryId;
+                List<WeatherForecast> forecast = WeatherForecastHandler.GetTerritoryForecast((ushort)territoryId);
                 Func<WeatherForecast, string> formatTime = (forecast) => WeatherForecastHandler.FormatForecastTime(forecast.Time);
+                var hubName = CosmicMoonRegistry.GetDisplayName(territoryId);
 
                 Svc.Chat.Print(new Dalamud.Game.Text.XivChatEntry()
                 {
-                    Message = $"Sinus Ardorum Weather - {forecast[0].Name}",
+                    Message = $"{hubName} Weather - {forecast[0].Name}",
                     Type = Dalamud.Game.Text.XivChatType.Echo,
                 });
                 for (int i = 1; i < forecast.Count; i++)

--- a/ICE/Ui/MainUi/Settings/GambaWheel.cs
+++ b/ICE/Ui/MainUi/Settings/GambaWheel.cs
@@ -52,10 +52,11 @@ namespace ICE.Ui.MainUi.Settings
             if (PlayerHelper.IsInCosmicZone())
             {
                 var territory = Player.Territory.RowId;
-                var itemId = CosmicHelper.PlanetCreditInfo[territory];
-                PlayerHelper.GetItemCount(itemId, out var credits);
-
-                ImGui.Text($"Current location: {territory} | Currency Amount: {credits}");
+                if (CosmicMoonRegistry.TryGetPlanetCreditItemId(territory, out var itemId))
+                {
+                    PlayerHelper.GetItemCount(itemId, out var credits);
+                    ImGui.Text($"Current location: {territory} | Currency Amount: {credits}");
+                }
             }
 
             ImGui.Separator();
@@ -128,10 +129,11 @@ namespace ICE.Ui.MainUi.Settings
             if (PlayerHelper.IsInCosmicZone())
             {
                 var territory = Player.Territory.RowId;
-                var itemId = CosmicHelper.PlanetCreditInfo[territory];
-                PlayerHelper.GetItemCount(itemId, out var credits);
-
-                ImGui.Text($"Current location: {territory} | Currency Amount: {credits}");
+                if (CosmicMoonRegistry.TryGetPlanetCreditItemId(territory, out var itemId))
+                {
+                    PlayerHelper.GetItemCount(itemId, out var credits);
+                    ImGui.Text($"Current location: {territory} | Currency Amount: {credits}");
+                }
             }
 
             ImGui.Separator();

--- a/ICE/Ui/MainUi/Settings/Settings_TableColumns.cs
+++ b/ICE/Ui/MainUi/Settings/Settings_TableColumns.cs
@@ -128,11 +128,6 @@ public static class Settings_TableColumns
 
     private static TurninState HighestTurnin = TurninState.Gold;
 
-    private static bool AnyTurnin = true;
-    private static bool TurninGold = false;
-    private static bool TurninSilver = false;
-    private static bool TurninBronze = false;
-
     public static void GeneralMissionSettings()
     {
         if (ImGui.Button("Quick Apply Turnins"))

--- a/ICE/Ui/MainUi/Settings/TravelSettings.cs
+++ b/ICE/Ui/MainUi/Settings/TravelSettings.cs
@@ -273,7 +273,7 @@ namespace ICE.Ui.MainUi.Settings.Settings_Table
             {
                 ImGui.Text($"Planet: {Player.Territory.Value.PlaceName.Value.Name}");
                 ImGui.Checkbox("Show fishing spot raycast", ref _fishingDebug.ShowFishRay);
-                if (PlayerHelper.LocalPlayer is { } player && _fishingDebug.ShowFishRay)
+                if (Player.Object is { } player && _fishingDebug.ShowFishRay)
                 {
                     _fishingDebug.Draw();
                 }

--- a/ICE/Ui/OverlayWindow.cs
+++ b/ICE/Ui/OverlayWindow.cs
@@ -7,6 +7,7 @@ using ICE.Ui.MainUi.Settings;
 using ICE.Utilities.Cosmic_Helper;
 using ICE.Utilities.ImGuiTools;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using static ICE.Utilities.Cosmic_Helper.CosmicHelper;
 
@@ -130,7 +131,8 @@ namespace ICE.Ui
                 ImGui.EndTooltip();
             }
             DrawModeSelectPopup("Overlay Mode Select");
-            if (PlayerHelper.IsInOizys() || PlayerHelper.IsInAuxesia())
+            // Cosmodrome drone search — any hub with HasCosmodrome (Oizys, Auxesia); same button logic for all
+            if (CosmicMoonRegistry.TryGetMoon(Player.Territory.RowId, out var hubMoon) && hubMoon.HasCosmodrome)
             {
                 ImGui.SameLine();
                 bool droneActive = SchedulerMain.State == IceState.ArtifactSearch;
@@ -475,13 +477,15 @@ namespace ICE.Ui
                 }
             }
         }
-        private static readonly (uint TerritoryId, string Asset, string Name, Func<bool> IsEnabled)[] Planets = new[]
-        {
-            ((uint)1237, "ICE.Resources.Sinus_Ardorum.png", "Sinus Ardorum", new Func<bool>(() => C.ItemFilter.HasFlag(ItemFilter.Sinus))),
-            ((uint)1291, "ICE.Resources.Phaenna.png", "Phaenna", new Func<bool>(() => C.ItemFilter.HasFlag(ItemFilter.Phaenna))),
-            ((uint)1310, "ICE.Resources.Oizys.png", "Oizys", new Func<bool>(() => C.ItemFilter.HasFlag(ItemFilter.Oizys))),
-            ((uint)1319, "ICE.Resources.Auxesia.png", "Auxesia", new Func<bool>(() => C.ItemFilter.HasFlag(ItemFilter.Auxesia)))
-        };
+        // Overlay weather/timed rows — one entry per moon from registry (stays in sync when filters change)
+        private static (uint TerritoryId, string Asset, string Name, Func<bool> IsEnabled)[] Planets =>
+            CosmicMoonRegistry.All
+                .Select(m => (
+                    m.TerritoryId,
+                    m.IconResource,
+                    m.DisplayName,
+                    (Func<bool>)(() => C.ItemFilter.HasFlag(m.PlanetFilter))))
+                .ToArray();
         private void DrawMoonAndIcon(string moonAsset, FontAwesomeIcon icon)
         {
             var moonTexture = Svc.Texture.GetFromManifestResource(Assembly.GetExecutingAssembly(), moonAsset).GetWrapOrEmpty();

--- a/ICE/Ui/Relic_XP.cs
+++ b/ICE/Ui/Relic_XP.cs
@@ -1,8 +1,6 @@
 ﻿using FFXIVClientStructs.FFXIV.Client.Game.WKS;
 using ICE.Utilities.Cosmic_Helper;
-using Lumina.Excel.Sheets;
-using System.Collections.Generic;
-namespace ICE.Ui
+using System.Collections.Generic;namespace ICE.Ui
 {
     internal class Relic_XP
     {
@@ -23,13 +21,6 @@ namespace ICE.Ui
             var job = selectedJob;
             var toolClassId = (byte)(job - 7);
             var stage = wksManager->ResearchModule->CurrentStages[toolClassId - 1];
-            var nextstate = wksManager->ResearchModule->UnlockedStages[toolClassId - 1];
-
-            // Unsure... why this is here? 
-            if (Svc.Data.GetExcelSheet<WKSCosmoToolClass>().TryGetRow(toolClassId, out var row))
-            {
-
-            }
 
             Dictionary<uint, XPType> XPTable = new Dictionary<uint, XPType>();
 
@@ -55,6 +46,8 @@ namespace ICE.Ui
             }
 
             bool MaxStage = XPTable.Where(x => x.Value.NeededXP != 0).Count() == 0;
+
+            var maxRelicStage = CosmicMoonRegistry.GetMaxRelicStage((uint)Svc.ClientState.TerritoryType);
 
             ImGui.Text($"Stage: {stage}");
             if (MaxStage)
@@ -87,7 +80,7 @@ namespace ICE.Ui
                 else
                     xpType = "???";
 
-                if (stage != CosmicHelper.MaxRelicLevel)
+                if (stage != maxRelicStage)
                 {
                     DrawXPBar($"Type: {xpType}", current, needed, size, max);
                 }

--- a/ICE/Ui/Relic_XP.cs
+++ b/ICE/Ui/Relic_XP.cs
@@ -221,7 +221,7 @@ namespace ICE.Ui
             foreach (var crafterJob in CosmicHelper.CrafterJobList)
             {
                 uint classScore = 0;
-                var score = wksManager->Scores;
+                var score = wksManager->State.Scores;
                 int jobId = (int)crafterJob;
                 classScore = (uint)score[jobId-8];
                 classScore = Math.Min(500_000, classScore);
@@ -234,7 +234,7 @@ namespace ICE.Ui
             foreach (var gatherJob in CosmicHelper.GatheringJobList)
             {
                 uint classScore = 0;
-                var score = wksManager->Scores;
+                var score = wksManager->State.Scores;
                 int jobId = (int)gatherJob;
                 classScore = (uint)score[jobId-8];
                 classScore = Math.Min(500_000, classScore);

--- a/ICE/Utilities/Cosmic_Helper/CosmicHelper.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicHelper.cs
@@ -140,11 +140,6 @@ public static unsafe partial class CosmicHelper
         [510] = new() { 172, 487 },
         [511] = new() { 352, 487 }
     };
-    public static Dictionary<uint, Vector3> HubCenter = new()
-    {
-        [1237] = new(2.84f, 1.55f, -0.06f),
-        [1291] = new(339.90f, 52.60f, -412.10f),
-        [1310] = new(-180.02f, 0.50f, 129.25f),
-        [1319] = new(291.00f, 205.78f, 376.02f)
-    };
+    // Hub return / navmesh anchor per moon — see CosmicMoonRegistry for coordinates
+    public static Dictionary<uint, Vector3> HubCenter = CosmicMoonRegistry.HubCenters;
 }

--- a/ICE/Utilities/Cosmic_Helper/CosmicHelper.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicHelper.cs
@@ -16,8 +16,11 @@ public static unsafe partial class CosmicHelper
     public static readonly int MaximumLevel = Player.MaxLevel;
     public static readonly float ImageSize = 24;
 
-    public static readonly int MaxRelicLevel = 17;
-    public static readonly float MaxRelicExpStatus = 17.6f;
+    // Relic XP bar cap (highest stage across all moons + overcap headroom).
+    public static readonly float MaxRelicExpStatus = CosmicMoonRegistry.MaxRelicExpBarCap;
+
+    // Shared cosmo credits (45690) — not the per-planet gamba tokens. Use this instead of hardcoding the ID.
+    public const uint CosmoCreditItemId = 45690;
 
 
 
@@ -140,6 +143,4 @@ public static unsafe partial class CosmicHelper
         [510] = new() { 172, 487 },
         [511] = new() { 352, 487 }
     };
-    // Hub return / navmesh anchor per moon — see CosmicMoonRegistry for coordinates
-    public static Dictionary<uint, Vector3> HubCenter = CosmicMoonRegistry.HubCenters;
 }

--- a/ICE/Utilities/Cosmic_Helper/CosmicMapMarkerNudges.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicMapMarkerNudges.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace ICE.Utilities.Cosmic_Helper;
+
+/// <summary>
+/// Some mission rows land on the same map flag. We bump them a tile so gather-route YAML keys stay unique.
+/// Hard overrides are in Overrides; Oizys rows 1317–1319 get a +1 nudge in TryGetOverlapNudge.
+/// If Auxesia has stacked markers too, add another override entry.
+/// </summary>
+internal static class CosmicMapMarkerNudges
+{
+    private static readonly Dictionary<uint, Vector2> Overrides = new()
+    {
+        [1272] = new(-340, 870),
+        [1264] = new(-573, 3),
+        [1296] = new(-514, 232),
+    };
+
+    public static bool TryGetOverride(uint missionRowId, out Vector2 mapFlag)
+    {
+        if (Overrides.TryGetValue(missionRowId, out mapFlag))
+            return true;
+
+        mapFlag = default;
+        return false;
+    }
+
+    // Mission row IDs 1317–1319 on Oizys — not territory 1319 (Auxesia).
+    public static bool TryGetOverlapNudge(uint missionRowId, Vector2 mapFlag, out Vector2 nudgedFlag)
+    {
+        if (missionRowId is >= 1317 and <= 1319
+            && missionRowId >= CosmicMissionBlocks.OizysStart
+            && missionRowId < CosmicMissionBlocks.AuxesiaStart)
+        {
+            nudgedFlag = new(mapFlag.X + 1, mapFlag.Y + 1);
+            return true;
+        }
+
+        nudgedFlag = default;
+        return false;
+    }
+}

--- a/ICE/Utilities/Cosmic_Helper/CosmicMissionBlocks.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicMissionBlocks.cs
@@ -1,0 +1,18 @@
+namespace ICE.Utilities.Cosmic_Helper;
+
+/// <summary>
+/// WKSMissionUnit row-id bands per moon release (legacy fallback + hand-authored lists).
+/// </summary>
+public static class CosmicMissionBlocks
+{
+    public const uint SinusStart = 1;
+    public const uint PhaennaStart = 545;
+    public const uint OizysStart = 1040;
+    public const uint AuxesiaStart = 1370;
+
+    /// <summary>First row ID after the last known Auxesia band (exclusive upper bound for legacy resolver).</summary>
+    public const uint UnknownMissionStart = 1703;
+
+    /// <summary>Row-id offset between Oizys and Auxesia mission blocks (1040 + 330 = 1370).</summary>
+    public const uint OizysToAuxesiaOffset = 330;
+}

--- a/ICE/Utilities/Cosmic_Helper/CosmicMissionLists.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicMissionLists.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ICE.Utilities.Cosmic_Helper;
+
+/// <summary>
+/// Unlock + quick-level mission IDs, rebuilt from the sheet on startup.
+/// The old giant static lists in CustomNotes.cs are gone — if a patch adds rows the heuristics miss,
+/// drop the row ID into ManualUnlockAdditions or ManualQuickLevelAdditions below.
+/// </summary>
+public static class CosmicMissionLists
+{
+    public static HashSet<uint> UnlockMissionIds { get; private set; } = [];
+    public static HashSet<uint> QuickLevelMissionIds { get; private set; } = [];
+
+    // Patch gap filler — verify in the mission UI before copying +330 offsets from Oizys.
+    public static HashSet<uint> ManualUnlockAdditions { get; } = [];
+    public static HashSet<uint> ManualQuickLevelAdditions { get; } = [];
+
+    public static void BuildFromSheet()
+    {
+        UnlockMissionIds.Clear();
+        QuickLevelMissionIds.Clear();
+
+        foreach (var (missionId, info) in CosmicHelper.SheetMissionDict)
+        {
+            if (!CosmicMoonRegistry.IsKnownCosmicTerritory(info.TerritoryId))
+                continue;
+
+            if (info.IsProvisional || info.IsCritical)
+                continue;
+
+            // Unlock chain: rank 1–5 standard missions on any cosmic hub
+            if (info.Rank is >= 1 and <= 5)
+                UnlockMissionIds.Add(missionId);
+
+            // Level mode: A-rank missions at the 10 / 50 / 90 tiers
+            if (info.Level is 10 or 50 or 90 && info.ARank)
+                QuickLevelMissionIds.Add(missionId);
+        }
+
+        foreach (var id in ManualUnlockAdditions)
+            UnlockMissionIds.Add(id);
+
+        foreach (var id in ManualQuickLevelAdditions)
+            QuickLevelMissionIds.Add(id);
+    }
+
+    public static bool IsUnlockMission(uint missionId) => UnlockMissionIds.Contains(missionId);
+
+    public static bool IsQuickLevelMission(uint missionId) => QuickLevelMissionIds.Contains(missionId);
+
+    public static IEnumerable<uint> UnlockMissionList => UnlockMissionIds;
+
+    public static IEnumerable<uint> QuickLevelList => QuickLevelMissionIds;
+
+    public static bool HasUnlockContent(uint territoryId) =>
+        UnlockMissionIds.Any(id =>
+            CosmicHelper.SheetMissionDict.TryGetValue(id, out var info) && info.TerritoryId == territoryId);
+
+    public static bool HasLevelingContent(uint territoryId) =>
+        QuickLevelMissionIds.Any(id =>
+            CosmicHelper.SheetMissionDict.TryGetValue(id, out var info) && info.TerritoryId == territoryId);
+}

--- a/ICE/Utilities/Cosmic_Helper/CosmicMoonContent.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicMoonContent.cs
@@ -1,0 +1,204 @@
+using ICE.Utilities;
+using ICE.Scheduler.Handlers;
+using ICE.Scheduler.Tasks;
+using ICE.Utilities.GatheringHelper;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ICE.Utilities.Cosmic_Helper;
+
+/// <summary>
+/// Content availability checks per hub — no in-game coords, only what is already in the repo/runtime cache.
+/// </summary>
+public static class CosmicMoonContent
+{
+    public static bool HasGatheringRoutes(uint territoryId)
+    {
+        if (!GatheringRouteLoader.LoadAllRoutes().TryGetValue(territoryId, out var flags))
+            return false;
+
+        return flags.Count > 0;
+    }
+
+    public static bool HasFishingHoles(uint territoryId) =>
+        GatheringUtil.MoonFishingLocations.ContainsKey(territoryId);
+
+    public static bool HasFishingPresets(uint territoryId)
+    {
+        foreach (var (missionId, info) in CosmicHelper.SheetMissionDict)
+        {
+            if (info.TerritoryId != territoryId || !info.Jobs.Contains(18))
+                continue;
+
+            if (GatheringUtil.FishingPreset.TryGetValue(missionId, out var presets) && presets.Count > 0)
+                return true;
+        }
+
+        return false;
+    }
+
+    public static bool HasNpcData(uint territoryId) =>
+        NpcData.MoonNpcs.ContainsKey(territoryId);
+
+    public static bool HasPlanetAethernet(uint territoryId) =>
+        Task_NavmeshMove.PlanetAethernet.ContainsKey(territoryId)
+        && Task_NavmeshMove.PlanetAethernet[territoryId].Count > 0;
+
+    public static bool HasRedAlertAnnouncements(uint territoryId) =>
+        AnnouncementHandlers.HasRedAlertData(territoryId);
+
+    public static int CountCriticalMissions(uint territoryId) =>
+        CosmicHelper.SheetMissionDict.Count(x =>
+            x.Value.TerritoryId == territoryId && x.Value.IsCritical);
+
+    public static int CountCriticalMissionsWithCoords(uint territoryId) =>
+        CosmicHelper.SheetMissionDict.Count(x =>
+            x.Value.TerritoryId == territoryId
+            && x.Value.IsCritical
+            && CosmicHelper.CriticalLocations.ContainsKey(x.Key));
+
+    public static (int withRoutes, int total) CountGatherMissionsWithRoutes(uint territoryId)
+    {
+        var routes = GatheringRouteLoader.LoadAllRoutes();
+        var total = 0;
+        var withRoutes = 0;
+
+        foreach (var (_, info) in CosmicHelper.SheetMissionDict)
+        {
+            if (info.TerritoryId != territoryId)
+                continue;
+            if (!info.Jobs.Contains(16) && !info.Jobs.Contains(17))
+                continue;
+
+            total++;
+            if (routes.TryGetValue(territoryId, out var zoneRoutes)
+                && zoneRoutes.ContainsKey(info.MapPosition))
+                withRoutes++;
+        }
+
+        return (withRoutes, total);
+    }
+
+    /// <summary>Logs one line per hub after dictionary build — highlights missing authored content.</summary>
+    public static void LogContentSummary()
+    {
+        foreach (var moon in CosmicMoonRegistry.All)
+        {
+            var territoryId = moon.TerritoryId;
+            var tags = new List<string>();
+
+            if (CosmicMoonRegistry.HasLevelingContent(moon))
+                tags.Add("leveling");
+            if (CosmicMoonRegistry.HasUnlockContent(moon))
+                tags.Add("unlock list");
+            if (HasPlanetAethernet(territoryId))
+                tags.Add("aethernet");
+            if (HasGatheringRoutes(territoryId))
+                tags.Add("gather routes");
+            if (HasFishingHoles(territoryId))
+                tags.Add("fish holes");
+            if (HasFishingPresets(territoryId))
+                tags.Add("fish presets");
+            if (HasNpcData(territoryId))
+                tags.Add("NPCs");
+            if (HasRedAlertAnnouncements(territoryId))
+                tags.Add("red-alert hints");
+
+            var criticalTotal = CountCriticalMissions(territoryId);
+            var criticalMapped = CountCriticalMissionsWithCoords(territoryId);
+            if (criticalTotal > 0)
+                tags.Add($"red-alert coords {criticalMapped}/{criticalTotal}");
+
+            var (gatherRoutes, gatherTotal) = CountGatherMissionsWithRoutes(territoryId);
+            if (gatherTotal > 0 && gatherRoutes < gatherTotal)
+                tags.Add($"gather YAML {gatherRoutes}/{gatherTotal}");
+
+            var missingScores = MissionScoresGenerator.CountMissing(territoryId);
+            if (missingScores > 0)
+                tags.Add($"MissionScores missing {missingScores}");
+
+            var summary = tags.Count > 0 ? string.Join(", ", tags) : "registry only (no authored routes/fish/red-alert yet)";
+            IceLogging.Info($"[CosmicMoonContent] {moon.DisplayName} ({territoryId}): {summary}");
+        }
+
+        ValidateRegistry();
+    }
+
+    /// <summary>
+    /// Startup sanity check: every registry moon should have NPCs, aethernet, etc.
+    /// Logs warnings for missing authored content (gather YAML, fish holes, red-alert coords).
+    /// Watch the [CosmicMoonContent] line on plugin load — Auxesia will look thin until you fill data.
+    /// </summary>
+    public static void ValidateRegistry()
+    {
+        NpcData.NpcType[] standardNpcTypes =
+        [
+            NpcData.NpcType.Repair,
+            NpcData.NpcType.Credit,
+            NpcData.NpcType.Relic,
+            NpcData.NpcType.Gamba,
+            NpcData.NpcType.RedAlert,
+        ];
+
+        foreach (var moon in CosmicMoonRegistry.All)
+        {
+            var territoryId = moon.TerritoryId;
+
+            if (!HasNpcData(territoryId))
+            {
+                IceLogging.Warning($"[CosmicMoonRegistry] {moon.DisplayName} ({territoryId}) has no NpcInfo entry");
+                continue;
+            }
+
+            foreach (var npcType in standardNpcTypes)
+            {
+                if (!NpcData.TryGetNpc(territoryId, npcType, out _))
+                    IceLogging.Warning($"[CosmicMoonRegistry] {moon.DisplayName} missing NpcInfo.{npcType}");
+            }
+
+            if (moon.HasCosmodrome && !NpcData.TryGetNpc(territoryId, NpcData.NpcType.Drone, out _))
+                IceLogging.Warning($"[CosmicMoonRegistry] {moon.DisplayName} has cosmodrome but no Drone NPC");
+
+            if (!HasPlanetAethernet(territoryId))
+                IceLogging.Warning($"[CosmicMoonRegistry] {moon.DisplayName} ({territoryId}) has no PlanetAethernet entries");
+
+            // Colleague-owned gaps — info only, not a hard failure
+            if (!HasFishingHoles(territoryId) && CosmicHelper.SheetMissionDict.Values.Any(x => x.TerritoryId == territoryId && x.Jobs.Contains(18)))
+                IceLogging.Info($"[CosmicMoonRegistry] {moon.DisplayName} has fisher missions but no MoonFishingLocations entry yet");
+
+            if (!HasGatheringRoutes(territoryId) && CosmicHelper.SheetMissionDict.Values.Any(x =>
+                    x.TerritoryId == territoryId && (x.Jobs.Contains(16) || x.Jobs.Contains(17))))
+                IceLogging.Info($"[CosmicMoonRegistry] {moon.DisplayName} has gather missions but no gathering route YAML yet");
+
+            if (!GatheringUtil.HasFishingRegistrar(territoryId))
+                IceLogging.Info($"[CosmicMoonRegistry] {moon.DisplayName} has no fishing preset registrar yet");
+
+            var criticalTotal = CountCriticalMissions(territoryId);
+            var criticalMapped = CountCriticalMissionsWithCoords(territoryId);
+            if (criticalTotal > 0 && criticalMapped < criticalTotal)
+            {
+                IceLogging.Info(
+                    $"[CosmicMoonRegistry] {moon.DisplayName} red-alert turn-in coords: {criticalMapped}/{criticalTotal} mapped");
+            }
+        }
+
+        // Catch stray territory IDs that aren't in CosmicMoonRegistry.All
+        foreach (var territoryId in NpcData.MoonNpcs.Keys)
+        {
+            if (!CosmicMoonRegistry.IsKnownCosmicTerritory(territoryId))
+                IceLogging.Warning($"[CosmicMoonRegistry] NpcInfo has territory {territoryId} but it is not in CosmicMoonRegistry.All");
+        }
+
+        foreach (var territoryId in Task_NavmeshMove.PlanetAethernet.Keys)
+        {
+            if (!CosmicMoonRegistry.IsKnownCosmicTerritory(territoryId))
+                IceLogging.Warning($"[CosmicMoonRegistry] PlanetAethernet has territory {territoryId} but it is not in CosmicMoonRegistry.All");
+        }
+
+        foreach (var territoryId in GatheringUtil.MoonFishingLocations.Keys)
+        {
+            if (!CosmicMoonRegistry.IsKnownCosmicTerritory(territoryId))
+                IceLogging.Warning($"[CosmicMoonRegistry] MoonFishingLocations has territory {territoryId} but it is not in CosmicMoonRegistry.All");
+        }
+    }
+}

--- a/ICE/Utilities/Cosmic_Helper/CosmicMoonRegistry.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicMoonRegistry.cs
@@ -26,6 +26,16 @@ public sealed class CosmicMoonDefinition
     public uint? DronebitBoxId { get; init; }
     /// <summary>Max relic research stage on this hub (agenda playlist goals).</summary>
     public int MaxRelicStage { get; init; }
+    /// <summary>Expedition log tab order (0 = Sinus … 3 = Auxesia).</summary>
+    public int ExpeditionTabIndex { get; init; }
+    /// <summary>First WKSMissionUnit row ID on this hub.</summary>
+    public uint MissionRowIdStart { get; init; }
+    /// <summary>Embedded gathering route folder under Resources/GatheringRoutes/.</summary>
+    public required string GatheringRoutesFolder { get; init; }
+    /// <summary>Agenda playlist option for max relic on this hub.</summary>
+    public PlaylistOptions MaxRelicPlaylistOption { get; init; }
+    /// <summary>Seed value for navmesh aethernet unlock count until WKSHistoryBoard is read.</summary>
+    public uint DefaultAethernetLogLevel { get; init; }
     /// <summary>Expedition log research icon under Resources/ResearchIcons.</summary>
     public string? ResearchIconResource { get; init; }
 }
@@ -40,7 +50,7 @@ public sealed class CosmicMoonDefinition
 /// <para>
 /// Mission territory still comes from <see cref="CosmicTerritoryResolver"/> (game PlaceName), not from row-id bands.
 /// Hand-authored data (NPC positions, gathering YAML, fish holes, MissionScores) stays per moon but uses
-/// <see cref="TerritoryId"/> and <see cref="DisplayName"/> from this type.
+/// <see cref="CosmicMoonDefinition.TerritoryId"/> and <see cref="CosmicMoonDefinition.DisplayName"/> from this type.
 /// </para>
 /// </remarks>
 public static class CosmicMoonRegistry
@@ -54,6 +64,11 @@ public static class CosmicMoonRegistry
         PlanetCreditItemId = 45691,
         HubCenter = new(2.84f, 1.55f, -0.06f),
         MaxRelicStage = 9,
+        ExpeditionTabIndex = 0,
+        MissionRowIdStart = CosmicMissionBlocks.SinusStart,
+        GatheringRoutesFolder = "1237_Sinus Ardorum",
+        MaxRelicPlaylistOption = PlaylistOptions.SinusMax,
+        DefaultAethernetLogLevel = 15,
         ResearchIconResource = "ICE.Resources.ResearchIcons.novice.png",
     };
 
@@ -66,6 +81,11 @@ public static class CosmicMoonRegistry
         PlanetCreditItemId = 48146,
         HubCenter = new(339.90f, 52.60f, -412.10f),
         MaxRelicStage = 14,
+        ExpeditionTabIndex = 1,
+        MissionRowIdStart = CosmicMissionBlocks.PhaennaStart,
+        GatheringRoutesFolder = "1291_Phaenna",
+        MaxRelicPlaylistOption = PlaylistOptions.PhaennaMax,
+        DefaultAethernetLogLevel = 15,
         ResearchIconResource = "ICE.Resources.ResearchIcons.intermediate.png",
     };
 
@@ -81,6 +101,11 @@ public static class CosmicMoonRegistry
         DronebitCreditId = 49170,
         DronebitBoxId = 50414,
         MaxRelicStage = 17,
+        ExpeditionTabIndex = 2,
+        MissionRowIdStart = CosmicMissionBlocks.OizysStart,
+        GatheringRoutesFolder = "1310_Oizys",
+        MaxRelicPlaylistOption = PlaylistOptions.OizysMax,
+        DefaultAethernetLogLevel = 17,
         ResearchIconResource = "ICE.Resources.ResearchIcons.advance.png",
     };
 
@@ -96,6 +121,12 @@ public static class CosmicMoonRegistry
         DronebitCreditId = 49171,
         DronebitBoxId = 50415,
         MaxRelicStage = 20,
+        ExpeditionTabIndex = 3,
+        MissionRowIdStart = CosmicMissionBlocks.AuxesiaStart,
+        // Gathering YAML: ICE/Resources/GatheringRoutes/1319_Auxesia/ — copy format from 1310_Oizys (MIN_/BTN_Flag_X_Y.yaml)
+        GatheringRoutesFolder = "1319_Auxesia",
+        MaxRelicPlaylistOption = PlaylistOptions.AuxesiaMax,
+        DefaultAethernetLogLevel = 2,
         ResearchIconResource = "ICE.Resources.ResearchIcons.expert.png",
     };
 
@@ -105,6 +136,12 @@ public static class CosmicMoonRegistry
 
     public static readonly IReadOnlyDictionary<uint, CosmicMoonDefinition> ByTerritoryId =
         All.ToDictionary(m => m.TerritoryId);
+
+    public static readonly IReadOnlyDictionary<PlaylistOptions, CosmicMoonDefinition> ByMaxRelicPlaylistOption =
+        All.ToDictionary(m => m.MaxRelicPlaylistOption);
+
+    public static readonly IReadOnlyList<PlaylistOptions> MaxRelicPlaylistOptions =
+        All.Select(m => m.MaxRelicPlaylistOption).ToArray();
 
     // These dictionaries back the existing CosmicHelper.PlanetCreditInfo / HubCenter / DronebitInfo fields
     public static readonly Dictionary<uint, uint> PlanetCredits =
@@ -176,15 +213,45 @@ public static class CosmicMoonRegistry
     public static CosmicMoonDefinition? GetMoonForTerritory(uint territoryId) =>
         TryGetMoon(territoryId, out var moon) ? moon : null;
 
-    /// <summary>Target relic stage for max-relic playlist goals — one lookup instead of hardcoded 9/14/17/20.</summary>
-    public static int GetMaxRelicGoal(PlaylistOptions option) => option switch
+    public static bool TryGetPlanetCreditItemId(uint territoryId, out uint itemId) =>
+        PlanetCredits.TryGetValue(territoryId, out itemId);
+
+    /// <summary>Target relic stage for max-relic playlist goals.</summary>
+    public static int GetMaxRelicGoal(PlaylistOptions option) =>
+        TryGetMoonForMaxRelicOption(option, out var moon) ? moon.MaxRelicStage : 0;
+
+    public static bool IsMaxRelicPlaylistGoal(PlaylistOptions option) =>
+        TryGetMoonForMaxRelicOption(option, out _);
+
+    public static bool TryGetMoonForMaxRelicOption(PlaylistOptions option, out CosmicMoonDefinition moon) =>
+        ByMaxRelicPlaylistOption.TryGetValue(option, out moon!);
+
+    /// <summary>Legacy row-id band when PlaceName data is missing (see CosmicTerritoryResolver).</summary>
+    public static uint ResolveTerritoryFromMissionRowId(uint missionRowId)
     {
-        PlaylistOptions.SinusMax => Sinus.MaxRelicStage,
-        PlaylistOptions.PhaennaMax => Phaenna.MaxRelicStage,
-        PlaylistOptions.OizysMax => Oizys.MaxRelicStage,
-        PlaylistOptions.AuxesiaMax => Auxesia.MaxRelicStage,
-        _ => 0,
-    };
+        if (missionRowId < CosmicMissionBlocks.PhaennaStart)
+            return Sinus.TerritoryId;
+        if (missionRowId < CosmicMissionBlocks.OizysStart)
+            return Phaenna.TerritoryId;
+        if (missionRowId < CosmicMissionBlocks.AuxesiaStart)
+            return Oizys.TerritoryId;
+        if (missionRowId < CosmicMissionBlocks.UnknownMissionStart)
+            return Auxesia.TerritoryId;
+
+        return 0;
+    }
+
+    /// <summary>True when Unlock_MissionList has at least one mission on this hub.</summary>
+    public static bool HasUnlockContent(CosmicMoonDefinition moon)
+    {
+        foreach (var missionId in CosmicHelper.Unlock_MissionList)
+        {
+            if (CosmicHelper.SheetMissionDict.TryGetValue(missionId, out var info) && info.TerritoryId == moon.TerritoryId)
+                return true;
+        }
+
+        return false;
+    }
 
     /// <summary>True when QuickLevelList has at least one mission on this hub.</summary>
     public static bool HasLevelingContent(CosmicMoonDefinition moon)

--- a/ICE/Utilities/Cosmic_Helper/CosmicMoonRegistry.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicMoonRegistry.cs
@@ -1,0 +1,201 @@
+using ICE.ConfigFiles;
+using ICE.Enums;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using static ICE.ConfigFiles.Config;
+
+namespace ICE.Utilities.Cosmic_Helper;
+
+/// <summary>
+/// Per-moon settings that are not on WKSMissionUnit (hand-tuned in the plugin).
+/// </summary>
+public sealed class CosmicMoonDefinition
+{
+    /// <summary>TerritoryType row ID — same value Player.Territory uses in-zone (e.g. 1319 = Auxesia).</summary>
+    public required uint TerritoryId { get; init; }
+    public required string DisplayName { get; init; }
+    public required string IconResource { get; init; }
+    public required ItemFilter PlanetFilter { get; init; }
+    public required uint PlanetCreditItemId { get; init; }
+    /// <summary>Hub stellar return / navmesh anchor for this moon.</summary>
+    public required Vector3 HubCenter { get; init; }
+    /// <summary>Oizys and Auxesia have the cosmodrome / drone vendor; Sinus and Phaenna do not.</summary>
+    public bool HasCosmodrome { get; init; }
+    public uint? DronebitCreditId { get; init; }
+    public uint? DronebitBoxId { get; init; }
+    /// <summary>Max relic research stage on this hub (agenda playlist goals).</summary>
+    public int MaxRelicStage { get; init; }
+    /// <summary>Expedition log research icon under Resources/ResearchIcons.</summary>
+    public string? ResearchIconResource { get; init; }
+}
+
+/// <summary>
+/// One place to define every cosmic hub (Sinus through Auxesia — final moon for this expansion).
+/// </summary>
+/// <remarks>
+/// Auxesia was the last moon added, but this registry is the uniform contract for <b>all</b> hubs:
+/// UI filters, agenda warnings, overlay planets, debug tables, credits, hub centers, and cosmodrome checks
+/// should go through here instead of hardcoding 1237 / 1291 / 1310 / 1319.
+/// <para>
+/// Mission territory still comes from <see cref="CosmicTerritoryResolver"/> (game PlaceName), not from row-id bands.
+/// Hand-authored data (NPC positions, gathering YAML, fish holes, MissionScores) stays per moon but uses
+/// <see cref="TerritoryId"/> and <see cref="DisplayName"/> from this type.
+/// </para>
+/// </remarks>
+public static class CosmicMoonRegistry
+{
+    public static readonly CosmicMoonDefinition Sinus = new()
+    {
+        TerritoryId = 1237,
+        DisplayName = "Sinus Ardorum",
+        IconResource = "ICE.Resources.Sinus_Ardorum.png",
+        PlanetFilter = ItemFilter.Sinus,
+        PlanetCreditItemId = 45691,
+        HubCenter = new(2.84f, 1.55f, -0.06f),
+        MaxRelicStage = 9,
+        ResearchIconResource = "ICE.Resources.ResearchIcons.novice.png",
+    };
+
+    public static readonly CosmicMoonDefinition Phaenna = new()
+    {
+        TerritoryId = 1291,
+        DisplayName = "Phaenna",
+        IconResource = "ICE.Resources.Phaenna.png",
+        PlanetFilter = ItemFilter.Phaenna,
+        PlanetCreditItemId = 48146,
+        HubCenter = new(339.90f, 52.60f, -412.10f),
+        MaxRelicStage = 14,
+        ResearchIconResource = "ICE.Resources.ResearchIcons.intermediate.png",
+    };
+
+    public static readonly CosmicMoonDefinition Oizys = new()
+    {
+        TerritoryId = 1310,
+        DisplayName = "Oizys",
+        IconResource = "ICE.Resources.Oizys.png",
+        PlanetFilter = ItemFilter.Oizys,
+        PlanetCreditItemId = 48147,
+        HubCenter = new(-180.02f, 0.50f, 129.25f),
+        HasCosmodrome = true,
+        DronebitCreditId = 49170,
+        DronebitBoxId = 50414,
+        MaxRelicStage = 17,
+        ResearchIconResource = "ICE.Resources.ResearchIcons.advance.png",
+    };
+
+    public static readonly CosmicMoonDefinition Auxesia = new()
+    {
+        TerritoryId = 1319,
+        DisplayName = "Auxesia",
+        IconResource = "ICE.Resources.Auxesia.png",
+        PlanetFilter = ItemFilter.Auxesia,
+        PlanetCreditItemId = 48148,
+        HubCenter = new(291.00f, 205.78f, 376.02f),
+        HasCosmodrome = true,
+        DronebitCreditId = 49171,
+        DronebitBoxId = 50415,
+        MaxRelicStage = 20,
+        ResearchIconResource = "ICE.Resources.ResearchIcons.expert.png",
+    };
+
+    public static readonly CosmicMoonDefinition[] All = [Sinus, Phaenna, Oizys, Auxesia];
+
+    public static readonly IReadOnlyList<uint> TerritoryIds = All.Select(m => m.TerritoryId).ToArray();
+
+    public static readonly IReadOnlyDictionary<uint, CosmicMoonDefinition> ByTerritoryId =
+        All.ToDictionary(m => m.TerritoryId);
+
+    // These dictionaries back the existing CosmicHelper.PlanetCreditInfo / HubCenter / DronebitInfo fields
+    public static readonly Dictionary<uint, uint> PlanetCredits =
+        All.ToDictionary(m => m.TerritoryId, m => m.PlanetCreditItemId);
+
+    public static readonly Dictionary<uint, Vector3> HubCenters =
+        All.ToDictionary(m => m.TerritoryId, m => m.HubCenter);
+
+    // Only moons with a cosmodrome populate this — do not index blindly on Sinus/Phaenna
+    public static readonly Dictionary<uint, CosmicHelper.Dronebit> Dronebits = All
+        .Where(m => m.DronebitCreditId is uint creditId && m.DronebitBoxId is uint boxId)
+        .ToDictionary(
+            m => m.TerritoryId,
+            m => new CosmicHelper.Dronebit { creditId = m.DronebitCreditId!.Value, boxId = m.DronebitBoxId!.Value });
+
+    public static bool TryGetMoon(uint territoryId, out CosmicMoonDefinition moon) =>
+        ByTerritoryId.TryGetValue(territoryId, out moon!);
+
+    public static string GetDisplayName(uint territoryId) =>
+        TryGetMoon(territoryId, out var moon) ? moon.DisplayName : $"Zone_{territoryId}";
+
+    public static bool IsKnownCosmicTerritory(uint territoryId) =>
+        ByTerritoryId.ContainsKey(territoryId);
+
+    /// <summary>Moons that have the cosmodrome / drone vendor (Oizys, Auxesia).</summary>
+    public static IEnumerable<CosmicMoonDefinition> WithCosmodrome =>
+        All.Where(m => m.HasCosmodrome);
+
+    public static string GetIconResource(uint territoryId) =>
+        TryGetMoon(territoryId, out var moon) ? moon.IconResource : Sinus.IconResource;
+
+    public static bool ItemFilterIncludesTerritory(ItemFilter filter, uint territoryId) =>
+        TryGetMoon(territoryId, out var moon) && filter.HasFlag(moon.PlanetFilter);
+
+    /// <summary>
+    /// Standard-mode missions (rank &lt; 6) enabled for a job on a given hub — same rules for every moon.
+    /// </summary>
+    public static int CountEnabledStandardMissions(uint territoryId, uint jobId)
+    {
+        var count = 0;
+        foreach (var (missionId, info) in CosmicHelper.SheetMissionDict)
+        {
+            if (info.TerritoryId != territoryId || !info.Jobs.Contains(jobId) || info.Rank >= 6)
+                continue;
+
+            if (C.MissionConfig.TryGetValue(missionId, out var cfg) && cfg.Enabled)
+                count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>Enabled missions on a hub (any rank) — used for startup logging.</summary>
+    public static int CountEnabledMissions(uint territoryId)
+    {
+        var count = 0;
+        foreach (var (missionId, info) in CosmicHelper.SheetMissionDict)
+        {
+            if (info.TerritoryId != territoryId)
+                continue;
+
+            if (C.MissionConfig.TryGetValue(missionId, out var cfg) && cfg.Enabled)
+                count++;
+        }
+
+        return count;
+    }
+
+    public static CosmicMoonDefinition? GetMoonForTerritory(uint territoryId) =>
+        TryGetMoon(territoryId, out var moon) ? moon : null;
+
+    /// <summary>Target relic stage for max-relic playlist goals — one lookup instead of hardcoded 9/14/17/20.</summary>
+    public static int GetMaxRelicGoal(PlaylistOptions option) => option switch
+    {
+        PlaylistOptions.SinusMax => Sinus.MaxRelicStage,
+        PlaylistOptions.PhaennaMax => Phaenna.MaxRelicStage,
+        PlaylistOptions.OizysMax => Oizys.MaxRelicStage,
+        PlaylistOptions.AuxesiaMax => Auxesia.MaxRelicStage,
+        _ => 0,
+    };
+
+    /// <summary>True when QuickLevelList has at least one mission on this hub.</summary>
+    public static bool HasLevelingContent(CosmicMoonDefinition moon)
+    {
+        foreach (var missionId in CosmicHelper.QuickLevelList)
+        {
+            if (CosmicHelper.SheetMissionDict.TryGetValue(missionId, out var info) && info.TerritoryId == moon.TerritoryId)
+                return true;
+        }
+
+        return false;
+    }
+}
+

--- a/ICE/Utilities/Cosmic_Helper/CosmicMoonRegistry.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicMoonRegistry.cs
@@ -48,9 +48,13 @@ public sealed class CosmicMoonDefinition
 /// UI filters, agenda warnings, overlay planets, debug tables, credits, hub centers, and cosmodrome checks
 /// should go through here instead of hardcoding 1237 / 1291 / 1310 / 1319.
 /// <para>
-/// Mission territory still comes from <see cref="CosmicTerritoryResolver"/> (game PlaceName), not from row-id bands.
-/// Hand-authored data (NPC positions, gathering YAML, fish holes, MissionScores) stays per moon but uses
-/// <see cref="CosmicMoonDefinition.TerritoryId"/> and <see cref="CosmicMoonDefinition.DisplayName"/> from this type.
+/// Mission territory still comes from <see cref="CosmicTerritoryResolver"/> (game PlaceName), not row-id bands.
+/// Hand-authored data (NPCs, gather YAML, fish holes, MissionScores) uses each moon's TerritoryId from here.
+/// </para>
+/// <para>
+/// Infra pass: call TryGetPlanetCreditItemId / TryGetHubCenter / TryGetDronebit instead of the legacy
+/// dict aliases on CosmicHelper and Mission_Info. Relic stage caps live on each moon (Auxesia = 20).
+/// Startup logs from CosmicMoonContent.ValidateRegistry() show what's still missing per hub.
 /// </para>
 /// </remarks>
 public static class CosmicMoonRegistry
@@ -143,7 +147,7 @@ public static class CosmicMoonRegistry
     public static readonly IReadOnlyList<PlaylistOptions> MaxRelicPlaylistOptions =
         All.Select(m => m.MaxRelicPlaylistOption).ToArray();
 
-    // These dictionaries back the existing CosmicHelper.PlanetCreditInfo / HubCenter / DronebitInfo fields
+    // Legacy dictionary aliases — prefer TryGetPlanetCreditItemId / TryGetHubCenter / TryGetDronebit.
     public static readonly Dictionary<uint, uint> PlanetCredits =
         All.ToDictionary(m => m.TerritoryId, m => m.PlanetCreditItemId);
 
@@ -216,6 +220,22 @@ public static class CosmicMoonRegistry
     public static bool TryGetPlanetCreditItemId(uint territoryId, out uint itemId) =>
         PlanetCredits.TryGetValue(territoryId, out itemId);
 
+    // Hub lookups — use these at call sites instead of indexing dicts directly.
+    public static bool TryGetHubCenter(uint territoryId, out Vector3 hubCenter) =>
+        HubCenters.TryGetValue(territoryId, out hubCenter);
+
+    public static bool TryGetDronebit(uint territoryId, out CosmicHelper.Dronebit dronebit) =>
+        Dronebits.TryGetValue(territoryId, out dronebit);
+
+    // Per-moon relic caps (Sinus 9 → Auxesia 20). UI/agenda should use these, not a flat 17.
+    public static int HighestMaxRelicStage => All.Max(m => m.MaxRelicStage);
+
+    /// <summary>Relic XP bar cap for max-stage sub-progress (was hardcoded 17.6).</summary>
+    public static float MaxRelicExpBarCap => HighestMaxRelicStage + 0.6f;
+
+    public static int GetMaxRelicStage(uint territoryId) =>
+        TryGetMoon(territoryId, out var moon) ? moon.MaxRelicStage : HighestMaxRelicStage;
+
     /// <summary>Target relic stage for max-relic playlist goals.</summary>
     public static int GetMaxRelicGoal(PlaylistOptions option) =>
         TryGetMoonForMaxRelicOption(option, out var moon) ? moon.MaxRelicStage : 0;
@@ -241,28 +261,11 @@ public static class CosmicMoonRegistry
         return 0;
     }
 
-    /// <summary>True when Unlock_MissionList has at least one mission on this hub.</summary>
-    public static bool HasUnlockContent(CosmicMoonDefinition moon)
-    {
-        foreach (var missionId in CosmicHelper.Unlock_MissionList)
-        {
-            if (CosmicHelper.SheetMissionDict.TryGetValue(missionId, out var info) && info.TerritoryId == moon.TerritoryId)
-                return true;
-        }
-
-        return false;
-    }
+    public static bool HasUnlockContent(CosmicMoonDefinition moon) =>
+        CosmicMissionLists.HasUnlockContent(moon.TerritoryId);
 
     /// <summary>True when QuickLevelList has at least one mission on this hub.</summary>
-    public static bool HasLevelingContent(CosmicMoonDefinition moon)
-    {
-        foreach (var missionId in CosmicHelper.QuickLevelList)
-        {
-            if (CosmicHelper.SheetMissionDict.TryGetValue(missionId, out var info) && info.TerritoryId == moon.TerritoryId)
-                return true;
-        }
-
-        return false;
-    }
+    public static bool HasLevelingContent(CosmicMoonDefinition moon) =>
+        CosmicMissionLists.HasLevelingContent(moon.TerritoryId);
 }
 

--- a/ICE/Utilities/Cosmic_Helper/CosmicTerritoryResolver.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicTerritoryResolver.cs
@@ -23,12 +23,15 @@ public static class CosmicTerritoryResolver
 
     // PlaceName sheet row ID -> TerritoryType row ID (e.g. 1237 = Sinus Ardorum)
     private static readonly Dictionary<uint, uint> PlaceNameToTerritory = new();
+    // Place names shared by multiple cosmic hubs — cannot map to one territory; use row-id fallback
+    private static readonly HashSet<uint> AmbiguousPlaceNames = new();
     private static readonly HashSet<uint> KnownTerritoryIds = new();
 
     // Log each edge case once so Dalamud logs stay readable during dictionary build
     private static readonly HashSet<uint> LoggedFallbackMissions = new();
     private static readonly HashSet<uint> LoggedMismatchMissions = new();
     private static readonly HashSet<uint> LoggedUnresolvedMissions = new();
+    private static readonly HashSet<uint> LoggedAmbiguousPlaceNames = new();
 
     /// <summary>
     /// Builds the PlaceName lookup table. Safe to call multiple times; only runs the heavy work once.
@@ -39,10 +42,12 @@ public static class CosmicTerritoryResolver
             return;
 
         PlaceNameToTerritory.Clear();
+        AmbiguousPlaceNames.Clear();
         KnownTerritoryIds.Clear();
         LoggedFallbackMissions.Clear();
         LoggedMismatchMissions.Clear();
         LoggedUnresolvedMissions.Clear();
+        LoggedAmbiguousPlaceNames.Clear();
 
         // Our four known hubs first (always present even if a sheet is missing on an older client)
         foreach (var territoryId in CosmicMoonRegistry.TerritoryIds)
@@ -62,7 +67,7 @@ public static class CosmicTerritoryResolver
 
         _initialized = true;
         IceLogging.Info(
-            $"[CosmicTerritoryResolver] Registered {KnownTerritoryIds.Count} territories, {PlaceNameToTerritory.Count} place name mappings");
+            $"[CosmicTerritoryResolver] Registered {KnownTerritoryIds.Count} territories, {PlaceNameToTerritory.Count} unique place names, {AmbiguousPlaceNames.Count} shared place names (row-id fallback)");
     }
 
     /// <summary>
@@ -113,7 +118,7 @@ public static class CosmicTerritoryResolver
 
     private static uint ResolveFromPlaceName(uint placeNameRowId)
     {
-        if (placeNameRowId == 0)
+        if (placeNameRowId == 0 || AmbiguousPlaceNames.Contains(placeNameRowId))
             return 0;
 
         return PlaceNameToTerritory.TryGetValue(placeNameRowId, out var territoryId) ? territoryId : 0;
@@ -123,22 +128,10 @@ public static class CosmicTerritoryResolver
     /// Pre-PlaceName logic: mission row IDs were allocated in blocks per moon release.
     /// Do not extend the last band blindly for a fifth moon — add the moon to <see cref="CosmicMoonRegistry"/> and rely on PlaceName instead.
     /// </summary>
-    private static uint ResolveLegacyMissionRowId(uint missionRowId)
-    {
-        if (missionRowId < 545)
-            return CosmicMoonRegistry.Sinus.TerritoryId;
-        if (missionRowId < 1040)
-            return CosmicMoonRegistry.Phaenna.TerritoryId;
-        if (missionRowId < 1370)
-            return CosmicMoonRegistry.Oizys.TerritoryId;
-        if (missionRowId < 1703)
-            return CosmicMoonRegistry.Auxesia.TerritoryId;
+    private static uint ResolveLegacyMissionRowId(uint missionRowId) =>
+        CosmicMoonRegistry.ResolveTerritoryFromMissionRowId(missionRowId);
 
-        // Row IDs at or above 1703 are unknown until game data maps them; returning 0 avoids wrong planet filters
-        return 0;
-    }
-
-    // TerritoryType uses several PlaceName columns; missions may reference any of them
+    // Only hub-specific names — PlaceNameZone/PlaceNameRegion are shared across all four moons
     private static void RegisterCosmicTerritory(uint territoryId)
     {
         if (!KnownTerritoryIds.Add(territoryId))
@@ -149,8 +142,6 @@ public static class CosmicTerritoryResolver
 
         var territory = TerritorySheet.GetRow(territoryId);
         RegisterPlaceName(territory.PlaceName.RowId, territoryId);
-        RegisterPlaceName(territory.PlaceNameZone.RowId, territoryId);
-        RegisterPlaceName(territory.PlaceNameRegion.RowId, territoryId);
 
         var map = territory.Map.Value;
         if (map.RowId != 0)
@@ -162,10 +153,22 @@ public static class CosmicTerritoryResolver
         if (placeNameRowId == 0)
             return;
 
-        if (PlaceNameToTerritory.TryGetValue(placeNameRowId, out var existing) && existing != territoryId)
+        if (AmbiguousPlaceNames.Contains(placeNameRowId))
+            return;
+
+        if (PlaceNameToTerritory.TryGetValue(placeNameRowId, out var existing))
         {
-            IceLogging.Warning(
-                $"[CosmicTerritoryResolver] PlaceName {placeNameRowId} maps to territory {existing} and {territoryId}; keeping {existing}");
+            if (existing != territoryId)
+            {
+                PlaceNameToTerritory.Remove(placeNameRowId);
+                AmbiguousPlaceNames.Add(placeNameRowId);
+                if (LoggedAmbiguousPlaceNames.Add(placeNameRowId))
+                {
+                    IceLogging.Debug(
+                        $"[CosmicTerritoryResolver] PlaceName {placeNameRowId} is shared across cosmic hubs; missions using it fall back to row-id bands.");
+                }
+            }
+
             return;
         }
 

--- a/ICE/Utilities/Cosmic_Helper/CosmicTerritoryResolver.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicTerritoryResolver.cs
@@ -1,0 +1,174 @@
+using Lumina.Excel.Sheets;
+using System.Collections.Generic;
+using static ICE.Utilities.ExcelHelper;
+
+namespace ICE.Utilities.Cosmic_Helper;
+
+/// <summary>
+/// Figures out which moon/planet a stellar mission belongs to.
+/// </summary>
+/// <remarks>
+/// Previously we guessed territory from WKSMissionUnit row ID ranges (see legacy fallback below).
+/// That broke whenever Square added a new moon and had to be updated by hand.
+/// The same resolver runs for Sinus, Phaenna, Oizys, and Auxesia (final moon) so every hub stays in sync.
+/// <para>
+/// Game data path: each mission has a <c>PlaceName</c> on WKSMissionUnit. We map that to a
+/// TerritoryType ID using place names from cosmic zones (see <see cref="CosmicMoonRegistry"/> and WKSTerritoryInfo).
+/// </para>
+/// Called once from <c>DictionaryCreation</c> before missions are loaded into <c>SheetMissionDict</c>.
+/// </remarks>
+public static class CosmicTerritoryResolver
+{
+    private static bool _initialized;
+
+    // PlaceName sheet row ID -> TerritoryType row ID (e.g. 1237 = Sinus Ardorum)
+    private static readonly Dictionary<uint, uint> PlaceNameToTerritory = new();
+    private static readonly HashSet<uint> KnownTerritoryIds = new();
+
+    // Log each edge case once so Dalamud logs stay readable during dictionary build
+    private static readonly HashSet<uint> LoggedFallbackMissions = new();
+    private static readonly HashSet<uint> LoggedMismatchMissions = new();
+    private static readonly HashSet<uint> LoggedUnresolvedMissions = new();
+
+    /// <summary>
+    /// Builds the PlaceName lookup table. Safe to call multiple times; only runs the heavy work once.
+    /// </summary>
+    public static void Initialize()
+    {
+        if (_initialized)
+            return;
+
+        PlaceNameToTerritory.Clear();
+        KnownTerritoryIds.Clear();
+        LoggedFallbackMissions.Clear();
+        LoggedMismatchMissions.Clear();
+        LoggedUnresolvedMissions.Clear();
+
+        // Our four known hubs first (always present even if a sheet is missing on an older client)
+        foreach (var territoryId in CosmicMoonRegistry.TerritoryIds)
+            RegisterCosmicTerritory(territoryId);
+
+        // Pick up any extra cosmic territories the client knows about (future moons, etc.)
+        var wksTerritorySheet = Svc.Data.GetExcelSheet<WKSTerritoryInfo>();
+        if (wksTerritorySheet != null)
+        {
+            foreach (var row in wksTerritorySheet)
+            {
+                var territoryId = row.TerritoryType.RowId;
+                if (territoryId != 0)
+                    RegisterCosmicTerritory(territoryId);
+            }
+        }
+
+        _initialized = true;
+        IceLogging.Info(
+            $"[CosmicTerritoryResolver] Registered {KnownTerritoryIds.Count} territories, {PlaceNameToTerritory.Count} place name mappings");
+    }
+
+    /// <summary>
+    /// Returns TerritoryType row ID for this mission, or 0 if we cannot place it on any moon.
+    /// </summary>
+    public static uint Resolve(WKSMissionUnit mission)
+    {
+        Initialize();
+
+        var missionId = mission.RowId;
+        var fromPlaceName = ResolveFromPlaceName(mission.PlaceName.RowId);
+        var fromLegacy = ResolveLegacyMissionRowId(missionId);
+
+        // Prefer game data — survives new moons without changing row-id thresholds
+        if (fromPlaceName != 0)
+        {
+            // If both methods disagree, trust PlaceName but leave a warning for us to verify after a patch
+            if (fromLegacy != 0 && fromPlaceName != fromLegacy && LoggedMismatchMissions.Add(missionId))
+            {
+                IceLogging.Warning(
+                    $"[CosmicTerritoryResolver] Mission {missionId} PlaceName -> {fromPlaceName} disagrees with legacy row-id -> {fromLegacy}. Using PlaceName.");
+            }
+
+            return fromPlaceName;
+        }
+
+        // Old row-id bands — kept so older/partial data still works until PlaceName is populated for every mission
+        if (fromLegacy != 0)
+        {
+            if (LoggedFallbackMissions.Add(missionId))
+            {
+                IceLogging.Debug(
+                    $"[CosmicTerritoryResolver] Mission {missionId} has no mapped PlaceName ({mission.PlaceName.RowId}); using legacy row-id -> {fromLegacy}");
+            }
+
+            return fromLegacy;
+        }
+
+        // Caller skips the mission — better than assigning Sinus (1237) by mistake
+        if (LoggedUnresolvedMissions.Add(missionId))
+        {
+            IceLogging.Warning(
+                $"[CosmicTerritoryResolver] Could not resolve territory for mission {missionId} (PlaceName row {mission.PlaceName.RowId})");
+        }
+
+        return 0;
+    }
+
+    private static uint ResolveFromPlaceName(uint placeNameRowId)
+    {
+        if (placeNameRowId == 0)
+            return 0;
+
+        return PlaceNameToTerritory.TryGetValue(placeNameRowId, out var territoryId) ? territoryId : 0;
+    }
+
+    /// <summary>
+    /// Pre-PlaceName logic: mission row IDs were allocated in blocks per moon release.
+    /// Do not extend the last band blindly for a fifth moon — add the moon to <see cref="CosmicMoonRegistry"/> and rely on PlaceName instead.
+    /// </summary>
+    private static uint ResolveLegacyMissionRowId(uint missionRowId)
+    {
+        if (missionRowId < 545)
+            return CosmicMoonRegistry.Sinus.TerritoryId;
+        if (missionRowId < 1040)
+            return CosmicMoonRegistry.Phaenna.TerritoryId;
+        if (missionRowId < 1370)
+            return CosmicMoonRegistry.Oizys.TerritoryId;
+        if (missionRowId < 1703)
+            return CosmicMoonRegistry.Auxesia.TerritoryId;
+
+        // Row IDs at or above 1703 are unknown until game data maps them; returning 0 avoids wrong planet filters
+        return 0;
+    }
+
+    // TerritoryType uses several PlaceName columns; missions may reference any of them
+    private static void RegisterCosmicTerritory(uint territoryId)
+    {
+        if (!KnownTerritoryIds.Add(territoryId))
+            return;
+
+        if (TerritorySheet == null)
+            return;
+
+        var territory = TerritorySheet.GetRow(territoryId);
+        RegisterPlaceName(territory.PlaceName.RowId, territoryId);
+        RegisterPlaceName(territory.PlaceNameZone.RowId, territoryId);
+        RegisterPlaceName(territory.PlaceNameRegion.RowId, territoryId);
+
+        var map = territory.Map.Value;
+        if (map.RowId != 0)
+            RegisterPlaceName(map.PlaceName.RowId, territoryId);
+    }
+
+    private static void RegisterPlaceName(uint placeNameRowId, uint territoryId)
+    {
+        if (placeNameRowId == 0)
+            return;
+
+        if (PlaceNameToTerritory.TryGetValue(placeNameRowId, out var existing) && existing != territoryId)
+        {
+            IceLogging.Warning(
+                $"[CosmicTerritoryResolver] PlaceName {placeNameRowId} maps to territory {existing} and {territoryId}; keeping {existing}");
+            return;
+        }
+
+        PlaceNameToTerritory[placeNameRowId] = territoryId;
+    }
+}

--- a/ICE/Utilities/Cosmic_Helper/CustomNotes.cs
+++ b/ICE/Utilities/Cosmic_Helper/CustomNotes.cs
@@ -92,6 +92,10 @@ public static partial class CosmicHelper
             "Second best weather missions for scoring, still good to focus over the basic A Ranks",
             896, 938);
 
+        // Auxesia (1370+): add AddMissions(...) blocks here when you have SPM from in-game runs.
+        // Same shape as Oizys above — float is avg score/min, string is tooltip text, last args are mission row IDs.
+        // QuickLevelList IDs below were +330 from Oizys; double-check in the mission table before trusting SPM IDs.
+
         foreach (var mission in notesDictonary)
         {
             SheetMissionDict[mission.Key].BestSPM = mission.Value;
@@ -146,6 +150,19 @@ public static partial class CosmicHelper
         1266, 1270, 1274, //
         1294, 1298, 1301, //
         1321, 1327, 1331, //
+
+        // Auxesia leveling IDs — derived +330 from Oizys; verify in-game before relying on them.
+        1370, 1375, 1378, //
+        1398, 1403, 1406, //
+        1426, 1431, 1434, //
+        1454, 1459, 1462, //
+        1482, 1487, 1490, //
+        1510, 1515, 1518, //
+        1538, 1543, 1546, //
+        1566, 1571, 1574, //
+        1596, 1600, 1604, //
+        1624, 1628, 1631, //
+        1651, 1657, 1661, //
     };
 
     public static List<uint> Unlock_MissionList = new()
@@ -223,7 +240,29 @@ public static partial class CosmicHelper
         // FSH
         1320, 1321, 1322, 1323, 1324, 1325, 1326, 1327,
 
-        // Auxesia — add mission row IDs (1370+) when leveling targets are chosen
+        // Auxesia (+330 from matching Oizys job blocks)
+        // CRP
+        1370, 1371, 1372, 1373, 1374, 1375, 1376, 1377,
+        // BSM
+        1398, 1399, 1400, 1401, 1402, 1403, 1404, 1405,
+        // ARM
+        1426, 1427, 1428, 1429, 1430, 1431, 1432, 1433,
+        // GSM
+        1454, 1455, 1456, 1457, 1458, 1459, 1460, 1461,
+        // LTW
+        1482, 1483, 1484, 1485, 1486, 1487, 1488, 1489,
+        // WVR
+        1510, 1511, 1512, 1513, 1514, 1515, 1516, 1517,
+        // ALC
+        1538, 1539, 1540, 1541, 1542, 1543, 1544, 1545,
+        // CUL
+        1566, 1567, 1568, 1569, 1570, 1571, 1572, 1573,
+        // MIN
+        1594, 1595, 1596, 1597, 1598, 1599, 1600, 1601,
+        // BTN
+        1622, 1623, 1624, 1625, 1626, 1627, 1628, 1629,
+        // FSH
+        1650, 1651, 1652, 1653, 1654, 1655, 1656, 1657,
     };
     public class LevelInfo
     {

--- a/ICE/Utilities/Cosmic_Helper/CustomNotes.cs
+++ b/ICE/Utilities/Cosmic_Helper/CustomNotes.cs
@@ -222,6 +222,8 @@ public static partial class CosmicHelper
         1292, 1293, 1294, 1295, 1296, 1297, 1298, 1299,
         // FSH
         1320, 1321, 1322, 1323, 1324, 1325, 1326, 1327,
+
+        // Auxesia — add mission row IDs (1370+) when leveling targets are chosen
     };
     public class LevelInfo
     {

--- a/ICE/Utilities/Cosmic_Helper/CustomNotes.cs
+++ b/ICE/Utilities/Cosmic_Helper/CustomNotes.cs
@@ -92,9 +92,9 @@ public static partial class CosmicHelper
             "Second best weather missions for scoring, still good to focus over the basic A Ranks",
             896, 938);
 
-        // Auxesia (1370+): add AddMissions(...) blocks here when you have SPM from in-game runs.
-        // Same shape as Oizys above — float is avg score/min, string is tooltip text, last args are mission row IDs.
-        // QuickLevelList IDs below were +330 from Oizys; double-check in the mission table before trusting SPM IDs.
+        // Auxesia (1370+): add AddMissions(...) blocks when you have SPM numbers from in-zone runs.
+        // Unlock / quick-level IDs are built automatically — see CosmicMissionLists.cs.
+        // If the sheet misses rows, use ManualUnlockAdditions / ManualQuickLevelAdditions there.
 
         foreach (var mission in notesDictonary)
         {
@@ -110,160 +110,12 @@ public static partial class CosmicHelper
         }
     }
 
-    public static List<uint> QuickLevelList = new()
-    {
-        // Sinus
-        3, 8, 19,      // CRP
-        48, 53, 64,    // ARM
-        93, 98, 109,   // BSM
-        138, 143, 154, // GSM
-        183, 188, 199, // LTW
-        228, 233, 244, // WVR
-        273, 278, 289, // ALC
-        318, 323, 334, // CUL
-        365, 369, 374, // MIN
-        410, 414, 419, // BTN
-        453, 458, 465, // FHS
+    /// <summary>Filled by CosmicMissionLists.BuildFromSheet() during startup — not a hand-edited list anymore.</summary>
+    public static IEnumerable<uint> QuickLevelList => CosmicMissionLists.QuickLevelList;
 
+    /// <summary>Filled by CosmicMissionLists.BuildFromSheet() during startup — not a hand-edited list anymore.</summary>
+    public static IEnumerable<uint> Unlock_MissionList => CosmicMissionLists.UnlockMissionList;
 
-        // Phaenna // 1 2 2
-        545, 556, 561, // CRP
-        587, 598, 603, // BSM
-        629, 640, 645, // ARM
-        671, 682, 687, // GSM
-        713, 724, 729, // LTW
-        755, 766, 771, // WVR
-        797, 808, 813, // ALC
-        839, 850, 855, // CUL
-        883, 903, 886, // MIN
-        925, 945, 928, // BTN
-        967, 973, 979, // FSH
-
-        1040, 1045, 1048, //
-        1068, 1073, 1076, //
-        1096, 1101, 1104, //
-        1124, 1129, 1132, //
-        1152, 1157, 1160, //
-        1180, 1185, 1188, //
-        1208, 1213, 1216, //
-        1236, 1241, 1244, //
-        1266, 1270, 1274, //
-        1294, 1298, 1301, //
-        1321, 1327, 1331, //
-
-        // Auxesia leveling IDs — derived +330 from Oizys; verify in-game before relying on them.
-        1370, 1375, 1378, //
-        1398, 1403, 1406, //
-        1426, 1431, 1434, //
-        1454, 1459, 1462, //
-        1482, 1487, 1490, //
-        1510, 1515, 1518, //
-        1538, 1543, 1546, //
-        1566, 1571, 1574, //
-        1596, 1600, 1604, //
-        1624, 1628, 1631, //
-        1651, 1657, 1661, //
-    };
-
-    public static List<uint> Unlock_MissionList = new()
-    {
-        // Sinus
-
-        // CRP
-        1, 2, 3, 4, 5, 8, 9, 11, 12, 13,
-        // BSM
-        46, 47, 48, 49, 50, 53, 54, 56, 57, 58,
-        // ARM
-        91, 92, 93, 94, 95, 98, 99, 101, 102, 103,
-        // GSM
-        136, 137, 138, 139, 140, 143, 144, 146, 147, 148,
-        // LTW
-        181, 182, 183, 184, 185, 188, 189, 191, 192, 193,
-        // WVR
-        226, 227, 228, 229, 230, 233, 234, 236, 237, 238,
-        // ALC
-        271, 272, 273, 274, 275, 278, 279, 281, 282, 283,
-        // CUL
-        316, 317, 318, 319, 320, 323, 324, 326, 327, 328,
-        // MIN
-        361, 362, 365, 366, 367, 369, 370, 371, 372,
-        // BTN
-        406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417,
-        // FSH
-        451, 452, 453, 454, 456, 457, 458, 459, 460, 461, 463,
-
-        // Phaenna
-        // CRP
-        545, 546, 547, 548, 549, 552, 553, 555, 556, 557,
-        // BSM
-        587, 588, 589, 590, 591, 594, 595, 597, 598, 599,
-        // ARM
-        629, 630, 631, 632, 633, 636, 637, 639, 640, 641,
-        // GSM
-        671, 672, 673, 674, 675, 678, 679, 681, 682, 683,
-        // LTW
-        713, 714, 715, 716, 717, 720, 721, 723, 724, 725,
-        // WVR
-        755, 756, 757, 758, 759, 762, 763, 765, 766, 767,
-        // ALC
-        797, 798, 799, 800, 801, 804, 805, 807, 808, 809,
-        // CUL
-        839, 840, 841, 842, 843, 846, 847, 849, 850, 851,
-        // MIN
-        881, 882, 883, 889, 890, 902, 903, 904, 911, 912,
-        // BTN
-        923, 924, 925, 930, 931, 932, 944, 945, 946, 947, 953, 954,
-        // FSH
-        965, 967, 968, 970, 971, 972, 973, 974, 975, 977,
-
-        // Oizys
-        // CRP
-        1040, 1041, 1042, 1043, 1044, 1045, 1046, 1047, 
-        // BSM
-        1068, 1069, 1070, 1071, 1072, 1073, 1074, 1075, 
-        // ARM
-        1096, 1097, 1098, 1099, 1100, 1101, 1102, 1103, 
-        // GSM
-        1124, 1125, 1126, 1127, 1128, 1129, 1130, 1131, 
-        // LTW
-        1152, 1153, 1154, 1155, 1156, 1157, 1158, 1159, 
-        //WVR
-        1180, 1181, 1182, 1183, 1184, 1185, 1186, 1187,  
-        // ALC
-        1208, 1209, 1210, 1211, 1212, 1213, 1214, 1215, 
-        // CUL
-        1236, 1237, 1238, 1239, 1240, 1241, 1242, 1243, 
-        // MIN
-        1264, 1265, 1266, 1267, 1268, 1269, 1270, 1271, 
-        // BTN
-        1292, 1293, 1294, 1295, 1296, 1297, 1298, 1299,
-        // FSH
-        1320, 1321, 1322, 1323, 1324, 1325, 1326, 1327,
-
-        // Auxesia (+330 from matching Oizys job blocks)
-        // CRP
-        1370, 1371, 1372, 1373, 1374, 1375, 1376, 1377,
-        // BSM
-        1398, 1399, 1400, 1401, 1402, 1403, 1404, 1405,
-        // ARM
-        1426, 1427, 1428, 1429, 1430, 1431, 1432, 1433,
-        // GSM
-        1454, 1455, 1456, 1457, 1458, 1459, 1460, 1461,
-        // LTW
-        1482, 1483, 1484, 1485, 1486, 1487, 1488, 1489,
-        // WVR
-        1510, 1511, 1512, 1513, 1514, 1515, 1516, 1517,
-        // ALC
-        1538, 1539, 1540, 1541, 1542, 1543, 1544, 1545,
-        // CUL
-        1566, 1567, 1568, 1569, 1570, 1571, 1572, 1573,
-        // MIN
-        1594, 1595, 1596, 1597, 1598, 1599, 1600, 1601,
-        // BTN
-        1622, 1623, 1624, 1625, 1626, 1627, 1628, 1629,
-        // FSH
-        1650, 1651, 1652, 1653, 1654, 1655, 1656, 1657,
-    };
     public class LevelInfo
     {
         public uint Level { get; set; } = 10;

--- a/ICE/Utilities/Cosmic_Helper/EnumDecoder.cs
+++ b/ICE/Utilities/Cosmic_Helper/EnumDecoder.cs
@@ -8,13 +8,12 @@ public static unsafe partial class CosmicHelper
 {
     public static string PlaylistOptionString(PlaylistOptions option)
     {
+        if (CosmicMoonRegistry.TryGetMoonForMaxRelicOption(option, out var moon))
+            return $"Max {moon.DisplayName} Relic [Lv. {moon.MaxRelicStage}]";
+
         return option switch
         {
             PlaylistOptions.None => "None",
-            PlaylistOptions.SinusMax => "Max Sinus Relic [Lv. 9]",
-            PlaylistOptions.PhaennaMax => "Max Phaenna Relic [Lv. 14]",
-            PlaylistOptions.OizysMax => "Max Oizys Relic [Lv. 17]",
-            PlaylistOptions.AuxesiaMax => "Max Auxesia Relic [Lv. 20]",
             PlaylistOptions.SelectedRelicLv => "Selected Relic Level",
             PlaylistOptions.CreditAmount => "Credit Amount",
             PlaylistOptions.PlanetAmount => "Planetary Credit Amount",

--- a/ICE/Utilities/Cosmic_Helper/EnumDecoder.cs
+++ b/ICE/Utilities/Cosmic_Helper/EnumDecoder.cs
@@ -14,6 +14,7 @@ public static unsafe partial class CosmicHelper
             PlaylistOptions.SinusMax => "Max Sinus Relic [Lv. 9]",
             PlaylistOptions.PhaennaMax => "Max Phaenna Relic [Lv. 14]",
             PlaylistOptions.OizysMax => "Max Oizys Relic [Lv. 17]",
+            PlaylistOptions.AuxesiaMax => "Max Auxesia Relic [Lv. 20]",
             PlaylistOptions.SelectedRelicLv => "Selected Relic Level",
             PlaylistOptions.CreditAmount => "Credit Amount",
             PlaylistOptions.PlanetAmount => "Planetary Credit Amount",

--- a/ICE/Utilities/Cosmic_Helper/MissionScoresGenerator.cs
+++ b/ICE/Utilities/Cosmic_Helper/MissionScoresGenerator.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace ICE.Utilities.Cosmic_Helper;
+
+/// <summary>
+/// Fills in MissionScores.csv rows from bronze sheet values when a mission is not in the embedded CSV yet.
+/// Debug → Table: Mission Info → "Copy Auxesia CSV" pastes rows to append to Resources/MissionScores.csv.
+/// </summary>
+public static class MissionScoresGenerator
+{
+    private static readonly Dictionary<uint, string> JobAbbreviations = new()
+    {
+        [8] = "CRP",
+        [9] = "BSM",
+        [10] = "ARM",
+        [11] = "GSM",
+        [12] = "LTW",
+        [13] = "WVR",
+        [14] = "ALC",
+        [15] = "CUL",
+        [16] = "MIN",
+        [17] = "BTN",
+        [18] = "FSH",
+    };
+
+    /// <summary>Missions in SheetMissionDict with no embedded CSV row — score from BronzeScore.</summary>
+    public static List<string> GetMissingCsvRows(uint? territoryId = null)
+    {
+        var rows = new List<string>();
+
+        foreach (var (missionId, info) in CosmicHelper.SheetMissionDict.OrderBy(x => x.Key))
+        {
+            if (CosmicHelper.MissionScoreDict.ContainsKey(missionId))
+                continue;
+            if (info.BronzeScore == 0)
+                continue;
+            if (territoryId is uint tid && info.TerritoryId != tid)
+                continue;
+            if (info.Jobs.Count == 0)
+                continue;
+
+            var jobCode = GetJobAbbreviation(info.Jobs[0]);
+            var name = EscapeCsvField(info.Name);
+            rows.Add($"{missionId},{jobCode},{name},{info.BronzeScore}");
+        }
+
+        return rows;
+    }
+
+    public static int CountMissing(uint? territoryId = null) =>
+        GetMissingCsvRows(territoryId).Count;
+
+    public static string BuildCsvText(uint? territoryId = null, bool includeHeader = true)
+    {
+        var rows = GetMissingCsvRows(territoryId);
+        var sb = new StringBuilder();
+        if (includeHeader)
+            sb.AppendLine("MissionID,Class,MissionName,Score");
+        foreach (var row in rows)
+            sb.AppendLine(row);
+        return sb.ToString();
+    }
+
+    public static bool TryExportMissingRows(string path, out string message, uint? territoryId = null)
+    {
+        var rows = GetMissingCsvRows(territoryId);
+        if (rows.Count == 0)
+        {
+            message = "No missing missions — every sheet mission has a CSV row or bronze score is 0.";
+            return false;
+        }
+
+        try
+        {
+            if (!path.EndsWith(".csv", System.StringComparison.OrdinalIgnoreCase))
+                path += ".csv";
+
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            File.WriteAllText(path, BuildCsvText(territoryId), Encoding.UTF8);
+            message = $"Exported {rows.Count} missing rows to {path}";
+            return true;
+        }
+        catch (System.Exception ex)
+        {
+            message = ex.Message;
+            return false;
+        }
+    }
+
+    private static string GetJobAbbreviation(uint jobId)
+    {
+        if (CosmicHelper.ClassInfoDict.TryGetValue(jobId, out var jobClass)
+            && !string.IsNullOrWhiteSpace(jobClass.shortName)
+            && jobClass.shortName != "???")
+            return jobClass.shortName;
+
+        return JobAbbreviations.TryGetValue(jobId, out var abbr) ? abbr : jobId.ToString();
+    }
+
+    private static string EscapeCsvField(string field)
+    {
+        field = field.Replace("<nbsp>", " ").Replace("<->", "").Trim();
+        if (field.Contains(',') || field.Contains('"') || field.Contains('\n'))
+            return $"\"{field.Replace("\"", "\"\"")}\"";
+        return field;
+    }
+}

--- a/ICE/Utilities/Cosmic_Helper/Mission_Info.cs
+++ b/ICE/Utilities/Cosmic_Helper/Mission_Info.cs
@@ -54,13 +54,8 @@ public static partial class CosmicHelper
         { 7, "VII" },
     };
 
-    public static readonly Dictionary<uint, uint> PlanetCreditInfo = new()
-    {
-        [1237] = 45691, // sinus
-        [1291] = 48146, // phaenna
-        [1310] = 48147, // Oizys
-        [1319] = 48148, // Auxesia
-    };
+    // Planet token item IDs per hub — defined in CosmicMoonRegistry (one place to update per moon)
+    public static readonly Dictionary<uint, uint> PlanetCreditInfo = CosmicMoonRegistry.PlanetCredits;
 
     public class Dronebit
     {
@@ -68,19 +63,8 @@ public static partial class CosmicHelper
         public uint boxId { get; set; } = 0;
     }
 
-    public static readonly Dictionary<uint, Dronebit> DronebitInfo = new()
-    {
-        [1310] = new() // Oizys
-        {
-            creditId = 49170,
-            boxId = 50414,
-        },
-        [1319] = new() // Auxesia
-        {
-            creditId = 49171,
-            boxId = 50415
-        }
-    };
+    // Oizys + Auxesia only; use TryGetValue before reading (Sinus/Phaenna have no drone currency)
+    public static readonly Dictionary<uint, Dronebit> DronebitInfo = CosmicMoonRegistry.Dronebits;
 
     // General use functions used across the codebase, specifically tied to cosmic related functions
     public static void OpenStellarMission()

--- a/ICE/Utilities/Cosmic_Helper/Mission_Info.cs
+++ b/ICE/Utilities/Cosmic_Helper/Mission_Info.cs
@@ -54,17 +54,11 @@ public static partial class CosmicHelper
         { 7, "VII" },
     };
 
-    // Planet token item IDs per hub — defined in CosmicMoonRegistry (one place to update per moon)
-    public static readonly Dictionary<uint, uint> PlanetCreditInfo = CosmicMoonRegistry.PlanetCredits;
-
     public class Dronebit
     {
         public uint creditId { get; set; } = 0;
         public uint boxId { get; set; } = 0;
     }
-
-    // Oizys + Auxesia only; use TryGetValue before reading (Sinus/Phaenna have no drone currency)
-    public static readonly Dictionary<uint, Dronebit> DronebitInfo = CosmicMoonRegistry.Dronebits;
 
     // General use functions used across the codebase, specifically tied to cosmic related functions
     public static void OpenStellarMission()
@@ -151,8 +145,10 @@ public static partial class CosmicHelper
 
             var score = wks->State.Scores[arrayIndex];
             var currentStage = researchModule->CurrentStages[arrayIndex];
-            var nextStage = currentStage == CosmicHelper.MaxRelicLevel
-                ? CosmicHelper.MaxRelicLevel
+            // Cap next stage by current hub (Auxesia allows higher than old flat 17).
+            var maxStage = CosmicMoonRegistry.GetMaxRelicStage((uint)Svc.ClientState.TerritoryType);
+            var nextStage = currentStage >= maxStage
+                ? maxStage
                 : (byte)(currentStage + 1);
 
             ClassInfo entry = new()

--- a/ICE/Utilities/Cosmic_Helper/Mission_Info.cs
+++ b/ICE/Utilities/Cosmic_Helper/Mission_Info.cs
@@ -23,7 +23,7 @@ public static partial class CosmicHelper
                 if (manager == null)
                     return 0; // or some default value
 
-                return manager->State.CurrentMissionUnitRowId;
+                return manager->State.CurrentMission.MissionUnitRowId;
             }
             catch (AccessViolationException)
             {

--- a/ICE/Utilities/Cosmic_Helper/RedAlert_Selection.cs
+++ b/ICE/Utilities/Cosmic_Helper/RedAlert_Selection.cs
@@ -227,6 +227,15 @@ public static partial class CosmicHelper
 
     #endregion
 
+    #region Auxesia
+
+    // Red-alert turn-ins for 1370+ aren't wired yet. When you're in zone:
+    // 1) Drop CriticalInfo blocks here (copy Oizys: RawLocation, MapInfo, NpcSelection 0/1)
+    // 2) AddKeys(...) in UpdateCriticalWeather below
+    // 3) Matching weather strings in AnnouncementHandlers for territory 1319
+
+    #endregion
+
     public static Dictionary<uint, CriticalInfo> CriticalLocations = new();
 
     public static void UpdateCriticalWeather()
@@ -288,6 +297,9 @@ public static partial class CosmicHelper
 
         AddKeys(BubbleBloom1α, 1348, 1362, 1366);
         AddKeys(BubbleBloom1β, 1355, 1364, 1368);
+
+        // Auxesia criticals — AddKeys(...) once the CriticalInfo blocks above exist.
+
     }
 
     private static void AddKeys(CriticalInfo location, params uint[] keys)

--- a/ICE/Utilities/GatheringHelper/FishingPresets.cs
+++ b/ICE/Utilities/GatheringHelper/FishingPresets.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿using ICE.Utilities.Cosmic_Helper;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ICE.Utilities.GatheringHelper;
 
@@ -10,10 +8,32 @@ public static partial class GatheringUtil
 {
     public static Dictionary<uint, List<string>> FishingPreset = new();
 
+    private static readonly Dictionary<uint, Action> FishingRegistrars = new()
+    {
+        [CosmicMoonRegistry.Sinus.TerritoryId] = RegisterSinus,
+        [CosmicMoonRegistry.Phaenna.TerritoryId] = RegisterPhaenna,
+        [CosmicMoonRegistry.Oizys.TerritoryId] = RegisterOizys,
+        [CosmicMoonRegistry.Auxesia.TerritoryId] = RegisterAuxesia,
+    };
+
     public static void RegisterPresets()
     {
-        RegisterSinus();
-        RegisterPhaenna();
-        RegisterOizys();
+        foreach (var moon in CosmicMoonRegistry.All)
+        {
+            if (FishingRegistrars.TryGetValue(moon.TerritoryId, out var register))
+                register();
+            else
+                PluginLog.Warning($"[FishingPresets] No registrar for {moon.DisplayName} ({moon.TerritoryId})");
+        }
+    }
+
+    internal static bool HasFishingRegistrar(uint territoryId) =>
+        FishingRegistrars.ContainsKey(territoryId);
+
+    private static void RegisterAuxesia()
+    {
+        // Auxesia fish presets (territory 1319) — wire up after MoonFishingLocations[1319] exists.
+        // Copy Fishing_Oizys.cs: one FishingPreset[missionRowId] = new() { "AutoHook preset name" } per FSH mission.
+        // Mission row IDs start at 1370 (see CosmicMissionBlocks.AuxesiaStart).
     }
 }

--- a/ICE/Utilities/GatheringHelper/GatheringRouteLoader.cs
+++ b/ICE/Utilities/GatheringHelper/GatheringRouteLoader.cs
@@ -325,16 +325,7 @@ public static class GatheringRouteLoader
         return createdRoutes;
     }
 
-    private static string GetZoneName(uint territoryId)
-    {
-        // You can expand this with a proper territory lookup if you have access to game sheets
-        // For now, using your existing mappings
-        return territoryId switch
-        {
-            1237 => "Sinus Ardorum",
-            1291 => "Phaenna",
-            1310 => "Oizys",
-            _ => $"Zone_{territoryId}" // Fallback for unknown zones
-        };
-    }
+    // Folder names like "1319_Auxesia" — display names live in CosmicMoonRegistry
+    private static string GetZoneName(uint territoryId) =>
+        CosmicMoonRegistry.GetDisplayName(territoryId);
 }

--- a/ICE/Utilities/GatheringHelper/GatheringRouteLoader.cs
+++ b/ICE/Utilities/GatheringHelper/GatheringRouteLoader.cs
@@ -144,7 +144,7 @@ public static class GatheringRouteLoader
         }
 
         // Create zone subdirectory: "ZoneId_ZoneName"
-        string zoneFolderName = SanitizeFolderName($"{zoneId}_{zoneName}");
+        string zoneFolderName = GetZoneFolderName(zoneId);
         string outputPath = Path.Combine(basePath, zoneFolderName);
 
         string fileName = $"{job}_Flag_{(int)flag.X}_{(int)flag.Y}.yaml";
@@ -283,7 +283,7 @@ public static class GatheringRouteLoader
                 };
 
                 // Create zone subdirectory
-                string zoneFolderName = SanitizeFolderName($"{territoryId}_{zoneName}");
+                string zoneFolderName = GetZoneFolderName(territoryId);
                 string outputPath = Path.Combine(basePath, zoneFolderName);
 
                 string fileName = $"{jobType}_Flag_{(int)mapFlag.X}_{(int)mapFlag.Y}.yaml";
@@ -325,7 +325,15 @@ public static class GatheringRouteLoader
         return createdRoutes;
     }
 
-    // Folder names like "1319_Auxesia" — display names live in CosmicMoonRegistry
+    // Folder names like "1319_Auxesia" — matches embedded Resources/GatheringRoutes/ and registry
+    private static string GetZoneFolderName(uint territoryId)
+    {
+        if (CosmicMoonRegistry.TryGetMoon(territoryId, out var moon))
+            return SanitizeFolderName(moon.GatheringRoutesFolder);
+
+        return SanitizeFolderName($"{territoryId}_{GetZoneName(territoryId)}");
+    }
+
     private static string GetZoneName(uint territoryId) =>
         CosmicMoonRegistry.GetDisplayName(territoryId);
 }

--- a/ICE/Utilities/GatheringHelper/GatheringUtil.cs
+++ b/ICE/Utilities/GatheringHelper/GatheringUtil.cs
@@ -1682,7 +1682,11 @@ public static unsafe partial class GatheringUtil
                     FishingSpot = new Vector3(-127.96f, -191.25f, -758.61f),
                 },
             },
-        }
+        },
+
+        // Auxesia (1319) — fish hole coords go here. Record in debug "Fishing Hole Editor", export C#, paste below.
+        // Pattern matches [1310] Oizys above: outer key = map flag, inner list = face + cast positions.
+        // [1319] = new() { ... },
     };
 
     public static Dictionary<string, List<uint>> MoonBaits = new();

--- a/ICE/Utilities/ICEDictornaryCreation.cs
+++ b/ICE/Utilities/ICEDictornaryCreation.cs
@@ -19,6 +19,9 @@ public sealed partial class ICE
         var MainMoonSheet = Svc.Data.GetExcelSheet<WKSMissionUnit>();
         string tag = "[Dictionary Creation]";
 
+        // Build PlaceName -> territory map before we assign TerritoryId on each CosmicInfo entry
+        CosmicTerritoryResolver.Initialize();
+
         foreach (var entry in MainMoonSheet)
         {
             Dictionary<ushort, CosmicHelper.CraftingInfo> crafts_Main = new();
@@ -105,25 +108,10 @@ public sealed partial class ICE
             // - - - HEY. BRONZE SCORE IS KEPT HERE - - - //
             uint bronze = missionToDo.Unknown2;
 
-            // TerritoryId that's assigned to each planet. There doesn't seem to be a direct way to grab this...
-            // So just going to hard assign this. TODO: Add last planet when it comes out
-            uint territoryId = 1237;
-            if (keyId < 545)
-            {
-                territoryId = 1237;
-            }
-            else if (keyId < 1040)
-            {
-                territoryId = 1291;
-            }
-            else if (keyId < 1370)
-            {
-                territoryId = 1310;
-            }
-            else if (keyId < 1703)
-            {
-                territoryId = 1319;
-            }
+            // Which moon this mission belongs to (TerritoryType ID, not mission row ID)
+            uint territoryId = CosmicTerritoryResolver.Resolve(entry);
+            if (territoryId == 0)
+                continue; // unresolved — logged once in resolver; do not default to Sinus
 
             // Map Marker Information
             var marker = missionToDo.MapMarker;
@@ -144,6 +132,8 @@ public sealed partial class ICE
             {
                 mapFlag = new(-514, 232);
             }
+            // Mission row IDs 1317–1319 (Oizys) — map markers stacked on the same flag; nudge for route editor keys
+            // Note: these are WKSMissionUnit row IDs, not territory IDs (Auxesia territory is 1319)
             else if (keyId is 1317 or 1318 or 1319)
             {
                 mapFlag = new(mapFlag.X + 1, mapFlag.Y + 1);
@@ -731,6 +721,11 @@ public sealed partial class ICE
             else if (C.ScoreKeeper.TryGetValue(missionId, out var storedScore) && storedScore != 0)
             {
                 entry.Value.ClassScore = storedScore;
+            }
+            else if (entry.Value.BronzeScore != 0)
+            {
+                // Missions 1370+ (Auxesia) may be missing from MissionScores.csv — bronze comes from game sheets
+                entry.Value.ClassScore = entry.Value.BronzeScore;
             }
             else
             {

--- a/ICE/Utilities/ICEDictornaryCreation.cs
+++ b/ICE/Utilities/ICEDictornaryCreation.cs
@@ -797,6 +797,7 @@ public sealed partial class ICE
 
         EnsureAllMission();
         GatheringUtil.RegisterPresets();
+        CosmicMoonContent.LogContentSummary();
 
         #region Config Stuff
 

--- a/ICE/Utilities/ICEDictornaryCreation.cs
+++ b/ICE/Utilities/ICEDictornaryCreation.cs
@@ -1,6 +1,5 @@
 ﻿using ICE.ConfigFiles;
 using ICE.Ui;
-using ICE.Ui.MainUi.ModeSelect_Modes;
 using ICE.Ui.MainUi.Settings;
 using ICE.Utilities.Cosmic_Helper;
 using ICE.Utilities.GatheringHelper;
@@ -14,18 +13,17 @@ namespace ICE;
 
 public sealed partial class ICE
 {
-    public static unsafe void DictionaryCreation()
+    public static void DictionaryCreation()
     {
         var MainMoonSheet = Svc.Data.GetExcelSheet<WKSMissionUnit>();
-        string tag = "[Dictionary Creation]";
 
         // Build PlaceName -> territory map before we assign TerritoryId on each CosmicInfo entry
         CosmicTerritoryResolver.Initialize();
 
         foreach (var entry in MainMoonSheet)
         {
-            Dictionary<ushort, CosmicHelper.CraftingInfo> crafts_Main = new();
-            Dictionary<ushort, CosmicHelper.CraftingInfo> crafts_Pre = new();
+            Dictionary<ushort, CraftingInfo> crafts_Main = new();
+            Dictionary<ushort, CraftingInfo> crafts_Pre = new();
             Dictionary<uint, int> gathering_Min = new();
             List<uint> jobs = new();
             Dictionary<int, int> relicXp = new();
@@ -118,26 +116,11 @@ public sealed partial class ICE
             Vector2 mapFlag = new(marker.Value.X - 1024, (marker.Value.Y - 1024));
             int radius = marker.Value.Radius;
 
-            // Oizys decided they were going to perfectly overlap 2 of the markers *-perfectly-*
-            // So specific missions have their positions changed *-ever-* so slightly to make them different for personal use
-            if (keyId == 1272)
-            {
-                mapFlag = new(-340, 870);
-            }
-            else if (keyId == 1264)
-            {
-                mapFlag = new(-573, 3);
-            }
-            else if (keyId == 1296)
-            {
-                mapFlag = new(-514, 232);
-            }
-            // Mission row IDs 1317–1319 (Oizys) — map markers stacked on the same flag; nudge for route editor keys
-            // Note: these are WKSMissionUnit row IDs, not territory IDs (Auxesia territory is 1319)
-            else if (keyId is 1317 or 1318 or 1319)
-            {
-                mapFlag = new(mapFlag.X + 1, mapFlag.Y + 1);
-            }
+            // Stacked map markers — nudge slightly so route editor keys stay unique per mission row.
+            if (CosmicMapMarkerNudges.TryGetOverride(keyId, out var overrideFlag))
+                mapFlag = overrideFlag;
+            else if (CosmicMapMarkerNudges.TryGetOverlapNudge(keyId, mapFlag, out var nudgedFlag))
+                mapFlag = nudgedFlag;
 
             // Mission Attributes/Flags. Esentially a quick way to know what is what kind of mission at a quick glance
             MissionAttributes attributes = MissionAttributes.None;
@@ -207,9 +190,8 @@ public sealed partial class ICE
 
                 if (isCritical)
                 {
-                    var requiredAmount = 3; // Sinus Specifically
-                    if (keyId > 535)
-                        requiredAmount = 2; // EVERY other planet
+                    // Sinus critical crafts need 3 items; every other hub uses 2 (was keyId > 535 before).
+                    var requiredAmount = territoryId == CosmicMoonRegistry.Sinus.TerritoryId ? 3 : 2;
 
                     if (Svc.Data.GetExcelSheet<Recipe>().TryGetRow(wksRecipeSheet.Value.Recipe[0].RowId, out var RecipeRow))
                     {
@@ -737,6 +719,8 @@ public sealed partial class ICE
 
         #region Mission Notes
 
+        // Sheet-driven unlock + quick-level lists (used to be huge static arrays in CustomNotes).
+        CosmicMissionLists.BuildFromSheet();
         CosmicHelper.CreateMissionNotes();
         foreach (var mission in MissionUnlock)
         {

--- a/ICE/Utilities/NpcInfo.cs
+++ b/ICE/Utilities/NpcInfo.cs
@@ -199,6 +199,16 @@ internal static class NpcData // Renamed the class to avoid conflict
         },
     };
 
+    public static bool TryGetMoon(uint territoryId, out Dictionary<NpcType, NPCInfo> npcs) =>
+        MoonNpcs.TryGetValue(territoryId, out npcs!);
+
+    public static bool TryGetNpc(uint territoryId, NpcType type, out NPCInfo npc)
+    {
+        npc = null!;
+        return MoonNpcs.TryGetValue(territoryId, out var moon)
+            && moon.TryGetValue(type, out npc!);
+    }
+
     public static Vector3 GetRandomPointInCircle(Vector3 center, float radius)
     {
         // Generate random angle (0 to 2π)

--- a/ICE/Utilities/NpcInfo.cs
+++ b/ICE/Utilities/NpcInfo.cs
@@ -3,11 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Xml.Linq;
-using System.Numerics; // Add this for Vector2 and Vector3
+using System.Numerics;
+using ICE.Utilities.Cosmic_Helper;
 
 namespace ICE.Utilities;
 
+/// <summary>
+/// Hub NPC positions keyed by territory ID (1237 / 1291 / 1310 / 1319).
+/// CosmicMoonContent.ValidateRegistry() warns if a moon in the registry is missing an entry here.
+/// </summary>
 internal static class NpcData // Renamed the class to avoid conflict
 {
     public enum NpcType

--- a/ICE/Utilities/PlayerHelper.cs
+++ b/ICE/Utilities/PlayerHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
+using ECommons;
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
@@ -10,67 +11,45 @@ using System.Collections.Generic;
 
 namespace ICE.Utilities;
 
+/// <summary>
+/// ICE-only player helpers. Most of the old duplicates now call ECommons (Player / GenericHelpers).
+/// Still here: cosmic zone checks, GetItemCount (HQ/NQ/+500k), repair scans, food buff, manip tracking.
+/// For distance / LocalPlayer / busy / screen-ready, use ECommons at the call site when you can.
+/// </summary>
 public class PlayerHelper
 {
-    // A lot of these functions are dupes to what is in Ecommons: GameHelper.Player
-    // Which means that a lot of these can get depreciated becuase they are either:
-    // -> Safer in how they are grabbed
-    // -> Less Reduntant in code
-    // -> Just genereally better 
-
     public static bool UsingSupportedJob()
     {
         var jobId = (uint)Player.Job;
-        return (CosmicHelper.CrafterJobList.Contains(jobId) || CosmicHelper.GatheringJobList.Contains(jobId));
+        return CosmicHelper.CrafterJobList.Contains(jobId) || CosmicHelper.GatheringJobList.Contains(jobId);
     }
 
-    // All cosmic hubs are listed in CosmicMoonRegistry — keep these wrappers so call sites stay readable
     public static bool IsInCosmicZone() =>
         CosmicMoonRegistry.IsKnownCosmicTerritory((uint)Svc.ClientState.TerritoryType);
 
-    public static bool IsOnMoon(CosmicMoonDefinition moon) => IsInZone(moon.TerritoryId);
+    public static bool CustomIsBusy =>
+        GenericHelpers.IsOccupied() || Player.IsCasting || Player.IsAnimationLocked;
 
-    public static bool IsInSinusArdorum() => IsOnMoon(CosmicMoonRegistry.Sinus);
-    public static bool IsInPhaenna() => IsOnMoon(CosmicMoonRegistry.Phaenna);
-    public static bool IsInOizys() => IsOnMoon(CosmicMoonRegistry.Oizys);
-    public static bool IsInAuxesia() => IsOnMoon(CosmicMoonRegistry.Auxesia);
-    public static bool IsInZone(uint zoneID) => Svc.ClientState.TerritoryType == zoneID;
-    public static IPlayerCharacter? LocalPlayer => Svc.Objects.LocalPlayer;
-    private static unsafe float AnimationLock => *(float*)((nint)ActionManager.Instance() + 8);
-    public static bool IsAnimationLocked => AnimationLock > 0;
-    public static bool CustomIsBusy => GenericHelpers.IsOccupied() || LocalPlayer.IsCasting || IsAnimationLocked;
-    public static bool IsScreenReady()
+    public static bool IsScreenReady() =>
+        GenericHelpers.IsScreenReady()
+        && !Svc.Condition[ConditionFlag.BetweenAreas]
+        && !Svc.Condition[ConditionFlag.BetweenAreas51]
+        && !Svc.Condition[ConditionFlag.OccupiedInCutSceneEvent]
+        && !Svc.Condition[ConditionFlag.WatchingCutscene]
+        && !Svc.Condition[ConditionFlag.WatchingCutscene78];
+
+    public static bool HasStatusId(params uint[] statusIDs)
     {
-        return !Svc.Condition[ConditionFlag.BetweenAreas] &&
-               !Svc.Condition[ConditionFlag.BetweenAreas51] &&
-               !Svc.Condition[ConditionFlag.OccupiedInCutSceneEvent] &&
-               !Svc.Condition[ConditionFlag.WatchingCutscene] &&
-               !Svc.Condition[ConditionFlag.WatchingCutscene78];
-    }
-    public static unsafe bool HasStatusId(params uint[] statusIDs)
-    {
-        if (LocalPlayer == null)
+        if (Player.Object is not IBattleChara battleChara)
             return false;
 
-        var statusID = LocalPlayer.StatusList
-            .Select(se => se.StatusId)
-            .ToList().Intersect(statusIDs)
-            .FirstOrDefault();
+        return battleChara.StatusList.Any(s => statusIDs.Contains((uint)s.StatusId));
+    }
 
-        return statusID != default;
-    }
-    public static int GetGp()
-    {
-        uint gp = LocalPlayer.CurrentGp;
-        return (int)gp;
-    }
-    public static int MaxGp()
-    {
-        var maxGp = LocalPlayer.MaxGp;
-        return (int)maxGp;
-    }
-    internal static unsafe float GetDistanceToPlayer(Vector3 v3) => Vector3.Distance(v3, Player.GameObject->Position);
-    internal static unsafe float GetDistanceToPlayer(IGameObject gameObject) => GetDistanceToPlayer(gameObject.Position);
+    public static int GetGp() => (int)(Player.Object?.CurrentGp ?? 0);
+
+    public static int MaxGp() => (int)(Player.Object?.MaxGp ?? 0);
+
     public static unsafe bool GetItemCount(uint itemID, out int count, bool includeHq = true, bool includeNq = true)
     {
         try
@@ -90,12 +69,16 @@ public class PlayerHelper
             return false;
         }
     }
+
     public static bool HasFoodRunning()
     {
         if (!C.UseGatheringFood || C.GatheringFood == 0)
             return true;
 
-        var foodBuff = LocalPlayer.StatusList.FirstOrDefault(x => x.StatusId == 48 && x.RemainingTime > 10f);
+        if (Player.Object is not { } localPlayer)
+            return false;
+
+        var foodBuff = localPlayer.StatusList.FirstOrDefault(x => x.StatusId == 48 && x.RemainingTime > 10f);
         if (foodBuff == null)
             return false;
         if (Svc.Data.GetExcelSheet<Item>().TryGetRow(C.GatheringFood, out var itemInfo))
@@ -109,6 +92,7 @@ public class PlayerHelper
 
         return false;
     }
+
     public static unsafe bool NeedsRepair(float below = 0)
     {
         string tag = "Needs Repair";
@@ -219,6 +203,7 @@ public class PlayerHelper
         public uint ActionId { get; set; }
         public bool HasUnlocked { get; set; }
     }
+
     public static Dictionary<uint, ManipInfo> ManipClassInfo = new()
     {
         [8] = new ManipInfo { ActionId = 4574, HasUnlocked = true },
@@ -230,6 +215,7 @@ public class PlayerHelper
         [14] = new ManipInfo { ActionId = 4580, HasUnlocked = true },
         [15] = new ManipInfo { ActionId = 4581, HasUnlocked = true },
     };
+
     public static unsafe void UpdateHasManip()
     {
         if (Player.IsBusy)

--- a/ICE/Utilities/PlayerHelper.cs
+++ b/ICE/Utilities/PlayerHelper.cs
@@ -24,11 +24,16 @@ public class PlayerHelper
         return (CosmicHelper.CrafterJobList.Contains(jobId) || CosmicHelper.GatheringJobList.Contains(jobId));
     }
 
-    public static bool IsInCosmicZone() => IsInSinusArdorum() || IsInPhaenna() || IsInOizys() || IsInAuxesia();
-    public static bool IsInSinusArdorum() => IsInZone(1237);
-    public static bool IsInPhaenna() => IsInZone(1291);
-    public static bool IsInOizys() => IsInZone(1310);
-    public static bool IsInAuxesia() => IsInZone(1319);
+    // All cosmic hubs are listed in CosmicMoonRegistry — keep these wrappers so call sites stay readable
+    public static bool IsInCosmicZone() =>
+        CosmicMoonRegistry.IsKnownCosmicTerritory((uint)Svc.ClientState.TerritoryType);
+
+    public static bool IsOnMoon(CosmicMoonDefinition moon) => IsInZone(moon.TerritoryId);
+
+    public static bool IsInSinusArdorum() => IsOnMoon(CosmicMoonRegistry.Sinus);
+    public static bool IsInPhaenna() => IsOnMoon(CosmicMoonRegistry.Phaenna);
+    public static bool IsInOizys() => IsOnMoon(CosmicMoonRegistry.Oizys);
+    public static bool IsInAuxesia() => IsOnMoon(CosmicMoonRegistry.Auxesia);
     public static bool IsInZone(uint zoneID) => Svc.ClientState.TerritoryType == zoneID;
     public static IPlayerCharacter? LocalPlayer => Svc.Objects.LocalPlayer;
     private static unsafe float AnimationLock => *(float*)((nint)ActionManager.Instance() + 8);

--- a/ICE/Utilities/Utils.cs
+++ b/ICE/Utilities/Utils.cs
@@ -84,14 +84,14 @@ public static unsafe class Utils
         }
         return false;
     }
-    internal static bool TryGetObjectByDataId(ulong dataId, out IGameObject? gameObject) => (gameObject = Svc.Objects.OrderBy(PlayerHelper.GetDistanceToPlayer).FirstOrDefault(x => x.BaseId == dataId)) != null;
+    internal static bool TryGetObjectByDataId(ulong dataId, out IGameObject? gameObject) => (gameObject = Svc.Objects.OrderBy(Player.DistanceTo).FirstOrDefault(x => x.BaseId == dataId)) != null;
     public static IGameObject? TryGetObjectNearestEventObject()
     {
-        return Svc.Objects.OrderBy(PlayerHelper.GetDistanceToPlayer).FirstOrDefault(x => x.ObjectKind == Dalamud.Game.ClientState.Objects.Enums.ObjectKind.EventObj);
+        return Svc.Objects.OrderBy(Player.DistanceTo).FirstOrDefault(x => x.ObjectKind == Dalamud.Game.ClientState.Objects.Enums.ObjectKind.EventObj);
     }
     public static IGameObject? TryGetObjectCollectionPoint()
     {
-        return Svc.Objects.OrderBy(PlayerHelper.GetDistanceToPlayer).FirstOrDefault(x => x.BaseId == 2014616 || x.BaseId == 2014618);
+        return Svc.Objects.OrderBy(Player.DistanceTo).FirstOrDefault(x => x.BaseId == 2014616 || x.BaseId == 2014618);
     }
     public static void TargetgameObject(IGameObject? gameObject)
     {

--- a/ICE/packages.lock.json
+++ b/ICE/packages.lock.json
@@ -14,6 +14,12 @@
         "resolved": "2.0.2",
         "contentHash": "VaHoEN6YHp0jXucxm67vfuRy8zo9ufiKSuaZ4ZudRi8xmWcEFMKxfCsg2nvYNvdISFTURDu+IHqADGh53+Bamw=="
       },
+      "ECommons": {
+        "type": "Direct",
+        "requested": "[3.2.1.6, )",
+        "resolved": "3.2.1.6",
+        "contentHash": "vr3lF7VyCEFaSB4nPbunH35WzIqfd40dMH4fmNkWO9dnOVDGuPD3eIc98APYUWduNU/LjAGnnQdrxHj5s+C1gg=="
+      },
       "NAudio": {
         "type": "Direct",
         "requested": "[2.3.0, )",
@@ -26,6 +32,19 @@
           "NAudio.Wasapi": "2.3.0",
           "NAudio.WinForms": "2.3.0",
           "NAudio.WinMM": "2.3.0"
+        }
+      },
+      "Pictomancy": {
+        "type": "Direct",
+        "requested": "[1.0.9, )",
+        "resolved": "1.0.9",
+        "contentHash": "pstT42Q08Q8189TFj2ettIWr+0MDKd9FQZcGunhycW1xrWC3ZnOcitsmJGxM2w+x6Ueghcfe95NudkKwJTsfuA==",
+        "dependencies": {
+          "KamiToolKit": "1.1.2",
+          "SharpDX.D3DCompiler": "4.2.0",
+          "SharpDX.Direct2D1": "4.2.0",
+          "SharpDX.Direct3D11": "4.2.0",
+          "SharpDX.Mathematics": "4.2.0"
         }
       },
       "TerraFX.Interop.Windows": {
@@ -184,24 +203,11 @@
         "resolved": "3.1.12",
         "contentHash": "iAg6zifihXEFS/t7fiHhZBGAdCp3FavsF4i2ZIDp0JfeYeDVzvmlbY1CNhhIKimaIzrzSi5M/NBFcWvZT2rB/A=="
       },
-      "ecommons": {
-        "type": "Project"
-      },
       "ottergui": {
         "type": "Project",
         "dependencies": {
           "JetBrains.Annotations": "[2024.3.0, )",
           "Microsoft.Extensions.DependencyInjection": "[9.0.2, )"
-        }
-      },
-      "pictomancy": {
-        "type": "Project",
-        "dependencies": {
-          "KamiToolKit": "[1.1.2, )",
-          "SharpDX.D3DCompiler": "[4.2.0, )",
-          "SharpDX.Direct2D1": "[4.2.0, )",
-          "SharpDX.Direct3D11": "[4.2.0, )",
-          "SharpDX.Mathematics": "[4.2.0, )"
         }
       }
     }


### PR DESCRIPTION
- One registry (`CosmicMoonRegistry`) for all cosmic hubs — credits, hub center, drone bits, relic caps, aethernet keys
- Unlock/quick-level mission lists built from the sheet at startup (`CosmicMissionLists`), not hand-edited ID lists
- Relic cap fix: was stuck at 17, Auxesia goes to 20
- `PlayerHelper` uses ECommons where it can; ICE-only stuff stays (item counts, repair, food, manip)
- OtterGui → SDK 15; removed dead aliases, unused fields, and debug hardcodes
- Startup log (`CosmicMoonContent`) shows what's still missing per hub

**Still needs in-game content for Auxesia (1319):** gather YAML, fish holes/presets, SPM notes, red-alert coords, announce strings. Code comments mark the spots.