### PR TITLE
Auxesia (7.51) follow-ups on top of upstream zone support

### DIFF
--- a/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
+++ b/ICE/Scheduler/Tasks/Task_NavmeshMove.cs
@@ -532,21 +532,21 @@ namespace ICE.Scheduler.Tasks
             },
             [CosmicMoonRegistry.Auxesia.TerritoryId] = new()
             {
-                new()
+                new() // The Timberlodge (hub)
                 {
                     MapSelector = 0,
                     AethernetId = 2015422,
                     Location = new(259.8f, 205.64f, 356.3f),
                     LandZone = new(260.9f, 205.6f, 355.6f)
                 },
-                new()
+                new() // Full Bloom Gardens
                 {
                     MapSelector = 1,
                     AethernetId = 2015423,
                     Location = new(-226.37f, 145.01f, -560.4f),
                     LandZone = new(-226.0f, 145.0f, -559.3f)
                 },
-                new()
+                new() // Pileus Pergola
                 {
                     MapSelector = 2,
                     AethernetId = 2015424,
@@ -723,7 +723,9 @@ namespace ICE.Scheduler.Tasks
                 }
             }
 
-            if (distance > 0)
+            // Both legs must be pathable — a null leg would otherwise make this route look artificially short
+            // (same guard as CalculateHubAethernet).
+            if (distance > 0 && aethernet.pathTo != null && aethernet.pathFrom != null)
             {
                 aethernet.distance = distance;
                 aethernet.Aethernet_TravelTo = closestAetheryte.AethernetId;

--- a/ICE/Ui/DebugWindowTabs/Ui_RelicInfo.cs
+++ b/ICE/Ui/DebugWindowTabs/Ui_RelicInfo.cs
@@ -5,7 +5,7 @@ namespace ICE.Ui.DebugWindowTabs
 {
     internal class Ui_RelicInfo
     {
-        public static List<string> XPtypes = ["I", "II", "III", "IV", "V", "VI"];
+        public static List<string> XPtypes = ["I", "II", "III", "IV", "V", "VI", "VII"];
         public static List<(string Name, uint Id)> jobOptions = new()
         {
             ("CRP", 8),

--- a/ICE/Ui/Relic_XP.cs
+++ b/ICE/Ui/Relic_XP.cs
@@ -77,6 +77,8 @@ using System.Collections.Generic;namespace ICE.Ui
                     xpType = "V";
                 else if (type.Key == 6)
                     xpType = "VI";
+                else if (type.Key == 7)
+                    xpType = "VII";
                 else
                     xpType = "???";
 


### PR DESCRIPTION
- Show research type VII in the Relic_XP and Ui_RelicInfo displays.
- CalculateAethernet: require both path legs to be non-null before registering the aethernet route (same guard CalculateHubAethernet already had) so an unpathable leg cannot make it look cheapest.

Changes already merged by other PRs and dropped here:
- Relic cap 17 -> 20 (MaxRelicLevel / MaxRelicExpStatus) for the 7.51 raise.
- Zone-name switches: GetZoneName()/MoonName() return Auxesia for 1319 (gathering-route folder naming: 1319_Auxesia).
- Guard dronebit lookups with DronebitInfo.TryGetValue in Task_StartMode and Task_CheckState: fixes a KeyNotFound crash in Sinus/Phaenna AgendaMode and counts Auxesia dronebits (resolves the upstream TODO).
- ShowAuxesiaMissions config flag alongside the existing per-zone bools.
- Fix duplicate MapSelector in PlanetAethernet[1319]: Pileus Pergola (2015424) is teleport-menu entry 2, not 1 - the duplicate teleported the bot to Full Bloom Gardens (2015423, entry 1) instead and left it stuck waiting at the wrong shard. Verified in-game via drone-search logs + menu order: Timberlodge 0, Full Bloom Gardens 1, Pileus 2.

I have done some testing:
- Relic grinding for crafters is working
- Dronebit shopping and cosmodrone automation is working
- Gambling is working but I do not think that the priorities are in place for the new items

Update: after rebase on top of other PRs only a few changes remains