### PR TITLE
Auxesia Tool Mastery (Master) mission support and additional BTN / MIN routes

### DIFF
--- a/ICE/Enums/MissionEnums.cs
+++ b/ICE/Enums/MissionEnums.cs
@@ -28,6 +28,7 @@ namespace ICE.Enums
         Critical,
         Provisional,
         Standard,
+        ToolMastery,
     }
 
     public enum TurninState

--- a/ICE/Enums/TableEnums.cs
+++ b/ICE/Enums/TableEnums.cs
@@ -74,10 +74,11 @@ namespace ICE.Enums
         BRank = 1 << 5,
         CRank = 1 << 6,
         DRank = 1 << 7,
+        Master = 1 << 8,
 
         All = RedAlert
             + Sequence + Weather + Timed
-            + ARank + BRank + CRank + DRank
+            + ARank + BRank + CRank + DRank + Master
     }
 
     public enum JobFilter

--- a/ICE/Resources/GatheringRoutes/1319_Auxesia/BTN_Flag_-307_-195.yaml
+++ b/ICE/Resources/GatheringRoutes/1319_Auxesia/BTN_Flag_-307_-195.yaml
@@ -1,0 +1,79 @@
+zone_id: 1319
+zone_name: Auxesia
+job: BTN
+flag:
+  x: -307
+  y: -195
+author: Le Vagabond
+date_modified: 2026-06-03T14:00:36.3000173Z
+nodes:
+- node_id: 35823
+  position:
+    x: -298.3883
+    y: 165.9324
+    z: -166.3439
+  land_zone:
+    x: -296.38025
+    y: 164.78757
+    z: -166.08173
+  radius_start: 121
+  radius_end: 7
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35824
+  position:
+    x: -300.2883
+    y: 165.8161
+    z: -168.0389
+  land_zone:
+    x: -299.53107
+    y: 164.63733
+    z: -169.73935
+  radius_start: 45
+  radius_end: 316
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35822
+  position:
+    x: -320.1752
+    y: 166.8389
+    z: -220.5574
+  land_zone:
+    x: -318.9847
+    y: 165.50066
+    z: -219.77597
+  radius_start: 147
+  radius_end: 312
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.79
+- node_id: 35826
+  position:
+    x: -272.8279
+    y: 165.8251
+    z: -239.0184
+  land_zone:
+    x: -272.34927
+    y: 164.52864
+    z: -237.68262
+  radius_start: 252
+  radius_end: 112
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35825
+  position:
+    x: -277.4182
+    y: 165.591
+    z: -238.2248
+  land_zone:
+    x: -277.53354
+    y: 164.63435
+    z: -237.54881
+  radius_start: 292
+  radius_end: 164
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0

--- a/ICE/Resources/GatheringRoutes/1319_Auxesia/BTN_Flag_-376_478.yaml
+++ b/ICE/Resources/GatheringRoutes/1319_Auxesia/BTN_Flag_-376_478.yaml
@@ -1,0 +1,93 @@
+zone_id: 1319
+zone_name: Unknown
+job: BTN
+flag:
+  x: -376
+  y: 478
+author: Le Vagabond
+date_modified: 2026-06-03T13:46:05.8511764Z
+nodes:
+- node_id: 35700
+  position:
+    x: -358.2594
+    y: 147.6315
+    z: 459.0703
+  land_zone:
+    x: -360.43875
+    y: 146.96368
+    z: 458.97583
+  radius_start: 296
+  radius_end: 125
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35699
+  position:
+    x: -349.8973
+    y: 147.7811
+    z: 470.4489
+  land_zone:
+    x: -351.0603
+    y: 146.96368
+    z: 471.76154
+  radius_start: 288
+  radius_end: 133
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35701
+  position:
+    x: -371.3044
+    y: 147.8657
+    z: 498.944
+  land_zone:
+    x: -370.29987
+    y: 147.2194
+    z: 498.06534
+  radius_start: 98
+  radius_end: 263
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.21
+- node_id: 35702
+  position:
+    x: -376.3199
+    y: 147.9751
+    z: 496.3911
+  land_zone:
+    x: -374.57025
+    y: 146.96368
+    z: 494.43964
+  radius_start: 84
+  radius_end: 248
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35698
+  position:
+    x: -403.0215
+    y: 147.8823
+    z: 458.4919
+  land_zone:
+    x: -401.09805
+    y: 146.96367
+    z: 460.0386
+  radius_start: 230
+  radius_end: 93
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35697
+  position:
+    x: -394.7104
+    y: 147.8797
+    z: 451.0711
+  land_zone:
+    x: -394.68707
+    y: 146.96368
+    z: 453.73996
+  radius_start: 205
+  radius_end: 81
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.76

--- a/ICE/Resources/GatheringRoutes/1319_Auxesia/BTN_Flag_-632_247.yaml
+++ b/ICE/Resources/GatheringRoutes/1319_Auxesia/BTN_Flag_-632_247.yaml
@@ -1,0 +1,93 @@
+zone_id: 1319
+zone_name: Auxesia
+job: BTN
+flag:
+  x: -632
+  y: 247
+author: Le Vagabond
+date_modified: 2026-06-03T15:28:56.8783099Z
+nodes:
+- node_id: 35844
+  position:
+    x: -620.3019
+    y: 184.4345
+    z: 264.3176
+  land_zone:
+    x: -620.72546
+    y: 183.50763
+    z: 263.47244
+  radius_start: 59
+  radius_end: 315
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.72
+- node_id: 35840
+  position:
+    x: -628.7512
+    y: 184.3431
+    z: 211.9242
+  land_zone:
+    x: -628.6686
+    y: 183.50763
+    z: 213.97954
+  radius_start: 145
+  radius_end: 65
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.75
+- node_id: 35839
+  position:
+    x: -634.9713
+    y: 184.1872
+    z: 218.9223
+  land_zone:
+    x: -633.267
+    y: 183.50763
+    z: 219.36342
+  radius_start: 187
+  radius_end: 83
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.51
+- node_id: 35843
+  position:
+    x: -630.6631
+    y: 184.2981
+    z: 271.6107
+  land_zone:
+    x: -629.69135
+    y: 183.50763
+    z: 271.00928
+  radius_start: 5
+  radius_end: 321
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.65
+- node_id: 35842
+  position:
+    x: -664.7987
+    y: 184.2953
+    z: 257.1884
+  land_zone:
+    x: -662.6925
+    y: 183.50763
+    z: 258.1622
+  radius_start: 132
+  radius_end: 34
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.65
+- node_id: 35841
+  position:
+    x: -664.5834
+    y: 184.4143
+    z: 250.6972
+  land_zone:
+    x: -663.2046
+    y: 183.50763
+    z: 251.57162
+  radius_start: 108
+  radius_end: 29
+  min_distance: 1
+  max_distance: 2
+  fan_height: 1.04

--- a/ICE/Resources/GatheringRoutes/1319_Auxesia/MIN_Flag_-376_478.yaml
+++ b/ICE/Resources/GatheringRoutes/1319_Auxesia/MIN_Flag_-376_478.yaml
@@ -1,0 +1,93 @@
+zone_id: 1319
+zone_name: Auxesia
+job: MIN
+flag:
+  x: -376
+  y: 478
+author: Le Vagabond
+date_modified: 2026-06-03T13:50:11.1004587Z
+nodes:
+- node_id: 35700
+  position:
+    x: -358.2594
+    y: 147.6315
+    z: 459.0703
+  land_zone:
+    x: -361.23636
+    y: 146.96368
+    z: 459.1643
+  radius_start: 296
+  radius_end: 125
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35699
+  position:
+    x: -349.8973
+    y: 147.7811
+    z: 470.4489
+  land_zone:
+    x: -351.64072
+    y: 146.96368
+    z: 471.04224
+  radius_start: 288
+  radius_end: 133
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35701
+  position:
+    x: -371.3044
+    y: 147.8657
+    z: 498.944
+  land_zone:
+    x: -369.7762
+    y: 146.96368
+    z: 495.80966
+  radius_start: 98
+  radius_end: 263
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.21
+- node_id: 35702
+  position:
+    x: -376.3199
+    y: 147.9751
+    z: 496.3911
+  land_zone:
+    x: -376.46738
+    y: 146.96368
+    z: 493.91974
+  radius_start: 84
+  radius_end: 248
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35698
+  position:
+    x: -403.0215
+    y: 147.8823
+    z: 458.4919
+  land_zone:
+    x: -401.84714
+    y: 146.96368
+    z: 460.12943
+  radius_start: 230
+  radius_end: 93
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35697
+  position:
+    x: -394.7104
+    y: 147.8797
+    z: 451.0711
+  land_zone:
+    x: -393.85278
+    y: 146.96368
+    z: 452.05576
+  radius_start: 205
+  radius_end: 81
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0.76

--- a/ICE/Resources/GatheringRoutes/1319_Auxesia/MIN_Flag_-633_246.yaml
+++ b/ICE/Resources/GatheringRoutes/1319_Auxesia/MIN_Flag_-633_246.yaml
@@ -1,0 +1,93 @@
+zone_id: 1319
+zone_name: Auxesia
+job: MIN
+flag:
+  x: -633
+  y: 246
+author: Le Vagabond
+date_modified: 2026-06-03T14:57:20.5377097Z
+nodes:
+- node_id: 35741
+  position:
+    x: -663.8409
+    y: 184.5458
+    z: 265.1513
+  land_zone:
+    x: -662.7963
+    y: 183.50763
+    z: 265.73404
+  radius_start: 171
+  radius_end: 9
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35742
+  position:
+    x: -666.6866
+    y: 184.7043
+    z: 261.681
+  land_zone:
+    x: -664.30634
+    y: 183.50763
+    z: 262.90244
+  radius_start: 168
+  radius_end: 311
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35744
+  position:
+    x: -636.4806
+    y: 184.6305
+    z: 210.7231
+  land_zone:
+    x: -637.4339
+    y: 183.50763
+    z: 212.60812
+  radius_start: 272
+  radius_end: 105
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35743
+  position:
+    x: -622.421
+    y: 184.4136
+    z: 210.7507
+  land_zone:
+    x: -624.179
+    y: 183.50763
+    z: 212.21802
+  radius_start: 262
+  radius_end: 99
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35745
+  position:
+    x: -613.671
+    y: 184.5012
+    z: 248.195
+  land_zone:
+    x: -614.0768
+    y: 183.50763
+    z: 247.02148
+  radius_start: 1
+  radius_end: 230
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0
+- node_id: 35746
+  position:
+    x: -616.2538
+    y: 184.6476
+    z: 259.3713
+  land_zone:
+    x: -615.5606
+    y: 183.50761
+    z: 258.3684
+  radius_start: 26
+  radius_end: 231
+  min_distance: 1
+  max_distance: 2
+  fan_height: 0

--- a/ICE/Scheduler/Handlers/CosmicHandler.cs
+++ b/ICE/Scheduler/Handlers/CosmicHandler.cs
@@ -1,4 +1,6 @@
-﻿using ECommons.GameHelpers;
+﻿using ECommons.Automation.UIInput;
+using ECommons.GameHelpers;
+using FFXIVClientStructs.FFXIV.Component.GUI;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Client.Game.WKS;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
@@ -18,6 +20,9 @@ namespace ICE.Utilities
 {
     internal class CosmicHandler
     {
+        // WKSMission category tab index for "Tool Mastery Missions" (0 = Basic, 3 = Tool Mastery).
+        internal const byte ToolMasteryTab = 3;
+
         internal unsafe static bool IsMissionTimedOut()
         {
             var c = UIState.Instance()->MassivePcContentTodo.Director;
@@ -95,8 +100,15 @@ namespace ICE.Utilities
                     foreach (var mission in criticalList)
                         allMissions.Add(mission.MissionUnitId);
                 }
+
+                // Tool Mastery (tab 3) has no getter; only readable while that tab is selected.
+                if (wks->SelectedTab == ToolMasteryTab && wks->Data != null)
+                {
+                    foreach (var mission in wks->Data->MissionList)
+                        allMissions.Add(mission.MissionUnitId);
+                }
             }
-                
+
             return allMissions;
         }
         internal unsafe static List<uint> Basic_AvailableMissions()
@@ -174,6 +186,60 @@ namespace ICE.Utilities
             }
 
             return allMissions;
+        }
+        // Tool Mastery (tab 3) has no dedicated getter; its missions are only readable from
+        // Data.MissionList while that tab is selected. Returns empty unless we're on tab 3.
+        internal unsafe static List<uint> ToolMastery_AvailableMissions()
+        {
+            List<uint> allMissions = new();
+
+            if (GenericHelpers.TryGetAddonMaster<WKSMission>(out var wksMission) && wksMission.IsAddonReady)
+            {
+                var wks = AgentWKSMission.Instance();
+                if (wks is null || !wks->IsAgentActive() || wks->Data == null)
+                    return allMissions;
+
+                if (wks->SelectedTab == ToolMasteryTab)
+                {
+                    foreach (var mission in wks->Data->MissionList)
+                        allMissions.Add(mission.MissionUnitId);
+                }
+            }
+
+            return allMissions;
+        }
+        // Tool Mastery (tab 3) has no getter, so we must actually switch the UI to it (by clicking the
+        // tab button - the agent SelectedTab field does not move the UI). Tab buttons are sequential:
+        // Basic=17, Provisional=18, Critical=19, Tool Mastery=20 (17 + tab index). CurrentTab = AtkValues[27].
+        // Returns true once we're on the requested tab.
+        internal unsafe static bool EnsureCategoryTab(byte tab)
+        {
+            try
+            {
+                var addonPtr = Svc.GameGui.GetAddonByName("WKSMission");
+                if (addonPtr.Address == nint.Zero)
+                    return false;
+
+                var addon = (AtkUnitBase*)addonPtr.Address;
+                if (!addon->IsVisible)
+                    return false;
+
+                if (addon->AtkValues[27].UInt == tab)
+                    return true;
+
+                var btn = addon->GetComponentButtonById((uint)(17 + tab));
+                if (btn != null && btn->IsEnabled && btn->AtkResNode->IsVisible())
+                {
+                    if (EzThrottler.Throttle("WKS Switch Category Tab", 250))
+                        btn->ClickAddonButton(addon);
+                }
+                return false;
+            }
+            catch (Exception ex)
+            {
+                IceLogging.Error($"EnsureCategoryTab threw: {ex.Message}");
+                return false;
+            }
         }
         internal unsafe static List<uint> VisibleMissions()
         {

--- a/ICE/Scheduler/Tasks/Task_CheckMissions.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckMissions.cs
@@ -19,6 +19,7 @@ namespace ICE.Scheduler.Tasks
             Timed,
             Sequence,
             Ex,
+            Master,
             A,
             B,
             C,
@@ -33,6 +34,7 @@ namespace ICE.Scheduler.Tasks
             [MissionKind.Timed] = new(),
             [MissionKind.Sequence] = new(),
             [MissionKind.Ex] = new(),
+            [MissionKind.Master] = new(),
             [MissionKind.A] = new(),
             [MissionKind.B] = new(),
             [MissionKind.C] = new(),
@@ -80,6 +82,7 @@ namespace ICE.Scheduler.Tasks
             {
                 entry = rank switch
                 {
+                    6 => MissionKind.Master, // Rank 6 non-provisional = Tool Mastery (separate in-game tab)
                     5 => MissionKind.Ex,
                     4 => MissionKind.A,
                     3 => MissionKind.B,
@@ -436,6 +439,13 @@ namespace ICE.Scheduler.Tasks
                     }
                 }
 
+                // Tool Mastery missions live in their own in-game tab (no dedicated getter),
+                // so handle them explicitly regardless of MissionTypePrio ordering.
+                if (MissionLibrary[MissionKind.Master].Count > 0)
+                {
+                    P.TaskManager.Enqueue(() => CheckMissions(MissionLibrary[MissionKind.Master], MissionTypes.ToolMastery), "Checking Tool Mastery tab for missions");
+                }
+
                 P.TaskManager.Enqueue(() => FindReroll(), "Find mission to reroll for");
             }
             else
@@ -471,9 +481,35 @@ namespace ICE.Scheduler.Tasks
 
                 var job = Goldjob != 0 ? Goldjob : Mission_Settings.SelectedJob;
 
-                if (CorrectJobTab(job))
+                // Tool Mastery missions live on their own category tab (3); everything else is Basic (0).
+                byte categoryTab = type is MissionTypes.ToolMastery ? CosmicHandler.ToolMasteryTab : (byte)0;
+
+                if (CorrectJobTab(job, categoryTab))
                 {
-                    if (mode == ModeSelect.LevelMode)
+                    if (type is MissionTypes.ToolMastery)
+                    {
+                        // Tool Mastery has no tab-independent getter, so we must be on its UI tab to read
+                        // the list. Click into it first; bail this cycle until the UI is actually there.
+                        if (!CosmicHandler.EnsureCategoryTab(CosmicHandler.ToolMasteryTab))
+                            return true;
+
+                        var masterAvail = CosmicHandler.ToolMastery_AvailableMissions();
+                        IceLogging.Verbose($"Checking Tool Mastery missions.\n" +
+                            $"Loaded mission Count: {missionList.Count()}\n" +
+                            $"Available on tab: {masterAvail.Count()}", tag);
+
+                        foreach (var missionId in missionList)
+                        {
+                            if (masterAvail.Contains(missionId))
+                            {
+                                LogInfo(missionId);
+                                Insert_GrabMissionTask(missionId);
+                                return true;
+                            }
+                        }
+                        return true;
+                    }
+                    else if (mode == ModeSelect.LevelMode)
                     {
                         var levelingMission = missionList.FirstOrDefault();
                         IceLogging.Verbose($"Leveling Mission: Job: {Mission_Settings.SelectedJob} | Mission: {levelingMission} | Level: {CosmicHelper.SheetMissionDict[levelingMission].Level}", debugOnly: true);
@@ -854,7 +890,7 @@ namespace ICE.Scheduler.Tasks
                 IceLogging.Error("HEY. YOU DIDN'T READ THE HELP ME PAGE. AND NOW YOU'RE MISSING NAVMESH. So... yeah... if things break this is why");
                 return true;
             }
-            else if (sheetInfo.Attributes.HasFlag(MissionAttributes.Gather))
+            else if (sheetInfo.Attributes.HasFlag(MissionAttributes.Gather) || sheetInfo.IsGreaterReach)
             {
                 var missionTerritory = sheetInfo.TerritoryId;
                 var mapId = sheetInfo.MapPosition;
@@ -1015,8 +1051,15 @@ namespace ICE.Scheduler.Tasks
 
                     var job = CosmicHelper.SheetMissionDict[missionId].Jobs.First();
 
-                    if (CorrectJobTab(job))
+                    // Tool Mastery missions are only readable/grabbable from their own tab (3).
+                    byte categoryTab = CosmicHelper.SheetMissionDict[missionId].Master ? CosmicHandler.ToolMasteryTab : (byte)0;
+
+                    if (CorrectJobTab(job, categoryTab))
                     {
+                        // Tool Mastery missions are only readable/grabbable from their own UI tab.
+                        if (categoryTab == CosmicHandler.ToolMasteryTab && !CosmicHandler.EnsureCategoryTab(CosmicHandler.ToolMasteryTab))
+                            return false;
+
                         IceLogging.Verbose("On the correct tab, we're going to see the total mission count", tag);
                         var allmissions = CosmicHandler.All_AvailableMissions();
                         IceLogging.Verbose($"All mission count: {allmissions.Count()} | Goal: {missionId}");
@@ -1113,6 +1156,7 @@ namespace ICE.Scheduler.Tasks
 
                             switch (rank)
                             {
+                                case 6: // Master, treated as EX+ tier
                                 case 5: AExRank.Add(missionId); break;
                                 case 4: ARank.Add(missionId); break;
                                 case 3: BRank.Add(missionId); break;
@@ -1369,7 +1413,7 @@ namespace ICE.Scheduler.Tasks
         }
 
         // functions that are used across things
-        private static unsafe bool CorrectJobTab(uint job)
+        private static unsafe bool CorrectJobTab(uint job, byte categoryTab = 0)
         {
             var agent = AgentWKSMission.Instance();
             if (agent == null)
@@ -1380,7 +1424,7 @@ namespace ICE.Scheduler.Tasks
                 return false;
             }
 
-            return AgentWKSMissionEx.SetSelectedJobTab(agent, (byte)job);
+            return AgentWKSMissionEx.SetSelectedJobTab(agent, (byte)job, categoryTab);
         }
         private static void Notes()
         {

--- a/ICE/Ui/DebugWindow.cs
+++ b/ICE/Ui/DebugWindow.cs
@@ -1,4 +1,5 @@
-﻿using ICE.Ui.DebugWindowTabs;
+﻿using Dalamud.Interface;
+using ICE.Ui.DebugWindowTabs;
 using ICE.Ui.MainUi.HelpFolder;
 using System.Collections.Generic;
 
@@ -6,6 +7,8 @@ namespace ICE.Ui;
 
 internal class DebugWindow : Window
 {
+    private bool _showSidebar = true;
+
     public DebugWindow() :
         base($"ICE {P.GetType().Assembly.GetName().Version} Debugger ###IceCosmicDebug1")
     {
@@ -15,6 +18,16 @@ internal class DebugWindow : Window
             MinimumSize = new Vector2(100, 100),
             MaximumSize = new Vector2(3000, 3000)
         };
+
+        // Title-bar toggle for the left tab list, so the window can be shrunk down to just the content.
+        TitleBarButtons.Add(new TitleBarButton
+        {
+            Icon = FontAwesomeIcon.Bars,
+            IconOffset = new Vector2(2, 1),
+            Click = _ => _showSidebar = !_showSidebar,
+            ShowTooltip = () => ImGui.SetTooltip(_showSidebar ? "Hide tab list" : "Show tab list"),
+        });
+
         P.windowSystem.AddWindow(this);
     }
 
@@ -82,27 +95,31 @@ internal class DebugWindow : Window
     {
         float spacing = 10f;
         float leftPanelWidth = 200f;
-        float rightPanelWidth = ImGui.GetContentRegionAvail().X - leftPanelWidth - spacing;
         float childHeight = ImGui.GetContentRegionAvail().Y;
 
-        if (ImGui.BeginChild("DebugSelector", new Vector2(leftPanelWidth, childHeight), true))
+        if (_showSidebar)
         {
-            foreach (var viewName in DebugViews.Keys)
+            if (ImGui.BeginChild("DebugSelector", new Vector2(leftPanelWidth, childHeight), true))
             {
-                bool isSelected = (selectedDebugView == viewName);
-                string label = isSelected ? $"→ {viewName}" : $"   {viewName}";
-
-                if (ImGui.Selectable(label, isSelected))
+                foreach (var viewName in DebugViews.Keys)
                 {
-                    selectedDebugView = viewName;
+                    bool isSelected = (selectedDebugView == viewName);
+                    string label = isSelected ? $"→ {viewName}" : $"   {viewName}";
+
+                    if (ImGui.Selectable(label, isSelected))
+                    {
+                        selectedDebugView = viewName;
+                    }
                 }
             }
+            ImGui.EndChild();
+
+            ImGui.SameLine(0, spacing);
         }
-        ImGui.EndChild();
 
-        ImGui.SameLine(0, spacing);
+        float rightPanelWidth = ImGui.GetContentRegionAvail().X;
 
-        if (ImGui.BeginChild("DebugContent", new System.Numerics.Vector2(rightPanelWidth, childHeight), true))
+        if (ImGui.BeginChild("DebugContent", new Vector2(rightPanelWidth, childHeight), true))
         {
             if (DebugViews.TryGetValue(selectedDebugView, out var drawAction))
             {

--- a/ICE/Ui/MainUi/ModeSelect_Modes/CosmicTable/Mission_Table.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/CosmicTable/Mission_Table.cs
@@ -607,8 +607,8 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes.CosmicTable
             public MissionColumn()
             {
                 Flags = ImGuiTableColumnFlags.None;
-                SetFlags(MissionFilter.RedAlert, MissionFilter.Sequence, MissionFilter.Weather, MissionFilter.Timed, MissionFilter.ARank, MissionFilter.BRank, MissionFilter.CRank, MissionFilter.DRank);
-                SetNames("Red Alert", "Sequence", "Weather", "Timed", "A Rank", "B Rank", "C Rank", "D Rank");
+                SetFlags(MissionFilter.RedAlert, MissionFilter.Sequence, MissionFilter.Weather, MissionFilter.Timed, MissionFilter.ARank, MissionFilter.BRank, MissionFilter.CRank, MissionFilter.DRank, MissionFilter.Master);
+                SetNames("Red Alert", "Sequence", "Weather", "Timed", "A Rank", "B Rank", "C Rank", "D Rank", "Master");
             }
 
             private static int GetMissionPriority(CosmicInfo info)
@@ -652,6 +652,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes.CosmicTable
                     {
                         string rank = item.SheetInfo.Rank switch
                         {
+                            6 => "M",
                             5 or 4 => "A",
                             3 => "B",
                             2 => "C",
@@ -675,6 +676,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes.CosmicTable
                 if (FilterValue.HasFlag(MissionFilter.BRank) && sheetInfo.BRank && !special) return true;
                 if (FilterValue.HasFlag(MissionFilter.CRank) && sheetInfo.CRank && !special) return true;
                 if (FilterValue.HasFlag(MissionFilter.DRank) && sheetInfo.Drank && !special) return true;
+                if (FilterValue.HasFlag(MissionFilter.Master) && sheetInfo.Master) return true;
 
                 return false;
             }
@@ -940,7 +942,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes.CosmicTable
             {
                 var sheetInfo = item.SheetInfo;
                 bool craftProfile = sheetInfo.Attributes.HasFlag(MissionAttributes.Craft);
-                bool gatherProfile = sheetInfo.Attributes.HasFlag(MissionAttributes.Gather);
+                bool gatherProfile = sheetInfo.Attributes.HasFlag(MissionAttributes.Gather) || sheetInfo.IsGreaterReach;
                 bool collectable = sheetInfo.Attributes.HasFlag(MissionAttributes.Collectables) || sheetInfo.Attributes.HasFlag(MissionAttributes.ReducedItems);
                 bool fishProfile = sheetInfo.Attributes.HasFlag(MissionAttributes.Fish);
 

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Mission_Setup.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Mission_Setup.cs
@@ -320,6 +320,7 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                     ImGui_Ice.DrawRankButton("Sequence", MissionFilter.Sequence, MissionTable);
                     ImGui_Ice.DrawRankButton("Weather", MissionFilter.Weather, MissionTable);
                     ImGui_Ice.DrawRankButton("Timed", MissionFilter.Timed, MissionTable);
+                    ImGui_Ice.DrawRankButton("Master", MissionFilter.Master, MissionTable);
                     ImGui_Ice.DrawRankButton("A Rank", MissionFilter.ARank, MissionTable);
                     ImGui_Ice.DrawRankButton("B Rank", MissionFilter.BRank, MissionTable);
                     ImGui_Ice.DrawRankButton("C Rank", MissionFilter.CRank, MissionTable);

--- a/ICE/Utilities/Cosmic_Helper/AgentWKSMissionEx.cs
+++ b/ICE/Utilities/Cosmic_Helper/AgentWKSMissionEx.cs
@@ -55,7 +55,7 @@ public static unsafe class AgentWKSMissionEx
     /// internal 0–11 job index. Also syncs MissionData and clears HasSavedTab.
     /// Returns false if the sig wasn't found or the agent/data is null.
     /// </summary>
-    public static bool SetSelectedJobTab(AgentWKSMission* agent, byte classJobId)
+    public static bool SetSelectedJobTab(AgentWKSMission* agent, byte classJobId, byte categoryTab = 0)
     {
         if (_jobIndexToClassJobId == null || agent == null || agent->Data == null) return false;
 
@@ -67,7 +67,7 @@ public static unsafe class AgentWKSMissionEx
             break;
         }
 
-        agent->SelectedTab = 0;
+        agent->SelectedTab = categoryTab;
         agent->Data->SelectedJobIndex = jobIndex;
         agent->Data->UpdateFlags = 1;
         // Clear HasSavedTab to prevent the game from overwriting our set on the next tick

--- a/ICE/Utilities/Cosmic_Helper/CosmicMapMarkerNudges.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicMapMarkerNudges.cs
@@ -35,7 +35,8 @@ internal static class CosmicMapMarkerNudges
 
             // Auxesia 
             1607, // 8 Node BTN - A Rank
-            1641, 1642, 1643 // BTN Nodes that overlap with the MIN nodes in the same area
+            1641, 1642, 1643, 1644, // BTN Nodes that overlap with the MIN nodes in the same area
+            1647, 1648, 1649 // BTN Master missions overlapping the MIN Master nodes at (-633, 246)
         };
 
         if (MissionNudges.Contains(missionRowId))

--- a/ICE/Utilities/Cosmic_Helper/CosmicSheets.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicSheets.cs
@@ -139,6 +139,14 @@ public static unsafe partial class CosmicHelper
         public bool BRank => Rank is 3;
         public bool CRank => Rank is 2;
         public bool Drank => Rank == 1 && !Attributes.HasFlag(MissionAttributes.Critical);
+        // Tool Mastery missions: Rank 6 like EX+, but not provisional/critical (EX+ are always weather/timed).
+        public bool Master => Rank == 6 && !IsProvisional && !IsCritical;
+        // Greater Reach missions are gathering missions whose base Gather flag was swapped for a
+        // GreaterReach_* variant during parsing; treat them as gathering for routing/profile purposes.
+        public bool IsGreaterReach => Attributes.HasFlag(MissionAttributes.GreaterReach_GatherX)
+            || Attributes.HasFlag(MissionAttributes.GreaterReach_Boon)
+            || Attributes.HasFlag(MissionAttributes.GreaterReach_Chain)
+            || Attributes.HasFlag(MissionAttributes.GreaterReach_Boon_Chain);
 
     }
     public static Dictionary<uint, CosmicInfo> SheetMissionDict = new();

--- a/ICE/Utilities/ICEDictornaryCreation.cs
+++ b/ICE/Utilities/ICEDictornaryCreation.cs
@@ -168,6 +168,9 @@ public sealed partial class ICE
                     122 => MissionAttributes.Fish | MissionAttributes.Collectables,
                     139 => jobs.Contains(18) ? MissionAttributes.Fish : MissionAttributes.Gather, // Critical
                     141 => MissionAttributes.Fish,
+                    // Auxesia Tool Mastery gather missions (Geological/Botanical). They use Greater Reach,
+                    // so the GreaterReach block below converts Chain+Boon into GreaterReach_Boon_Chain.
+                    312 or 313 => MissionAttributes.Gather | MissionAttributes.Score_Chain | MissionAttributes.Score_Boon,
                     _ => MissionAttributes.None
                 };
             }


### PR DESCRIPTION
## Summary
Adds support for Auxesia **Tool Mastery ("Master") missions** - the new rank/category that wasn't selectable or schedulable before - plus the Greater Reach gather handling they need, some route data, and a small debug-window QOL.

## Master mission category
- New `MissionFilter.Master` with a **"Master" filter button** in mission setup (next to Timed) and a column option, a `MissionKind.Master` scheduler bucket, and a `CosmicInfo.Master` predicate (`Rank == 6 && !provisional && !critical`). The rank column renders **"M"**.
- These were previously invisible (Rank 6 matched no A/B/C/D filter and weren't weather/timed like EX+). They now list and can be selected/scheduled in Standard mode.

## Tool Mastery tab
- Tool Mastery missions live on a **separate in-game tab** (`SelectedTab == 3`) with no tab-independent getter (unlike Basic/Provisional/Critical). The scheduler now clicks into that tab (`EnsureCategoryTab`, tab button id 20) and reads `Data.MissionList` to find/grab them.
- `AgentWKSMissionEx.SetSelectedJobTab` takes an optional category-tab argument; `MissionTypes.ToolMastery` routes through `CheckTabs`/`CheckMissions`.

## Greater Reach gather missions
- Missions using the Greater Reach action have their base `Gather` flag swapped for a `GreaterReach_*` variant during parsing, so the table profile column and gather routing (both keyed on `HasFlag(Gather)`) skipped them. Added `CosmicInfo.IsGreaterReach` and OR'd it into both - the profile picker now shows and routing recognises them.
- Mapped the Auxesia Geological/Botanical mastery missions (`WKSMissionText` 312/313) to `Gather | Score_Chain | Score_Boon`, so the Greater Reach block classifies them as `GreaterReach_Boon_Chain` and `GetMissionKind` assigns the **"Greater Reach [Boon + Chain]"** profile.

## Other
- **Map-marker nudges**: BTN missions `1644` and the BTN Master missions `1647-1649` overlap MIN flags; nudged so they get their own entry in the gather route editor.
- **Debug window**: title-bar button (hamburger) to toggle the left tab list so the window can be shrunk to just the content.
- **Routes**: added captured MIN/BTN gathering routes for Auxesia (Tool Mastery `(-633,246)`/`(-632,247)` and others).
