### PR TITLE
Add "Time Expired" auto-turnin goal + fix nav for master missions

### DIFF
--- a/ICE/Enums/MissionEnums.cs
+++ b/ICE/Enums/MissionEnums.cs
@@ -39,6 +39,9 @@ namespace ICE.Enums
         Gold = 3,
         Critical = 4,
         SequenceGold = 5,
+        // Never turn in on score; only when the mission timer expires. Useful for missions that
+        // extend their timer as you hit goals (e.g. Tool Mastery) so you keep maxing score.
+        TimeExpired = 6,
     }
 
     public enum ArtisanCraftType

--- a/ICE/Scheduler/Tasks/Task_CheckMissions.cs
+++ b/ICE/Scheduler/Tasks/Task_CheckMissions.cs
@@ -880,6 +880,8 @@ namespace ICE.Scheduler.Tasks
             var sheetInfo = CosmicHelper.SheetMissionDict[missionId];
             var missionConfig = C.MissionConfig[missionId];
 
+            IceLogging.Info($"[MoveCheck] id={missionId} attrs=[{sheetInfo.Attributes}] gather={sheetInfo.IsGatherMission} fish={sheetInfo.IsFishMission} gr={sheetInfo.IsGreaterReach} unsupported={UnsupportedMissions.Ids.Contains(missionId)} manual={missionConfig.ManualMode} mapPos=({sheetInfo.MapPosition.X},{sheetInfo.MapPosition.Y})", tag);
+
             if (missionConfig.ManualMode || UnsupportedMissions.Ids.Contains(missionId))
             {
                 IceLogging.Info("Mission is currently in manual mode, or not supported. So not going to pathfind to it.", tag);
@@ -890,7 +892,7 @@ namespace ICE.Scheduler.Tasks
                 IceLogging.Error("HEY. YOU DIDN'T READ THE HELP ME PAGE. AND NOW YOU'RE MISSING NAVMESH. So... yeah... if things break this is why");
                 return true;
             }
-            else if (sheetInfo.Attributes.HasFlag(MissionAttributes.Gather) || sheetInfo.IsGreaterReach)
+            else if (sheetInfo.IsGatherMission || sheetInfo.IsGreaterReach)
             {
                 var missionTerritory = sheetInfo.TerritoryId;
                 var mapId = sheetInfo.MapPosition;
@@ -920,7 +922,7 @@ namespace ICE.Scheduler.Tasks
                     return true;
                 }
             }
-            else if (sheetInfo.Attributes.HasFlag(MissionAttributes.Fish))
+            else if (sheetInfo.IsFishMission)
             {
                 var location = sheetInfo.MapPosition;
                 var territory = sheetInfo.TerritoryId;

--- a/ICE/Ui/MainUi/ModeSelect_Modes/CosmicTable/Mission_Table.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/CosmicTable/Mission_Table.cs
@@ -811,9 +811,10 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes.CosmicTable
                     if (C.MissionConfig.TryGetValue(item.Id, out var configInfo))
                     {
                         var highestTurnin = configInfo.TurninGoal;
-                        var goldEnabled = highestTurnin >= TurninState.Gold;
-                        var silverEnabled = highestTurnin >= TurninState.Silver;
-                        var bronzeEnabled = highestTurnin >= TurninState.Bronze;
+                        var timeExpired = highestTurnin == TurninState.TimeExpired;
+                        var goldEnabled = !timeExpired && highestTurnin >= TurninState.Gold;
+                        var silverEnabled = !timeExpired && highestTurnin >= TurninState.Silver;
+                        var bronzeEnabled = !timeExpired && highestTurnin >= TurninState.Bronze;
 
                         using (ImRaii.PushColor(ImGuiCol.Text, goldEnabled ? GoldColor : DisabledColor))
                         {
@@ -842,6 +843,17 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes.CosmicTable
                                 C.SaveDebounced();
                             }
                         }
+                        ImGui.SameLine();
+                        using (ImRaii.PushColor(ImGuiCol.Text, timeExpired ? GoldColor : DisabledColor))
+                        {
+                            if (ImGuiEx.IconButton(FontAwesomeIcon.Clock, "##TimeExpired"))
+                            {
+                                configInfo.TurninGoal = TurninState.TimeExpired;
+                                C.SaveDebounced();
+                            }
+                        }
+                        if (ImGui.IsItemHovered())
+                            ImGui.SetTooltip("Only turn in when the mission timer expires (keep gathering for max score).\nUseful for Tool Mastery missions that extend their timer on goal completion.");
 
                     }
 

--- a/ICE/Ui/MainUi/ModeSelect_Modes/Expedition_Log.cs
+++ b/ICE/Ui/MainUi/ModeSelect_Modes/Expedition_Log.cs
@@ -395,9 +395,10 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                             ImGui.SetCursorPosX(cursorPosX + (availWidth - totalWidth) * 0.5f);
 
                             var turninGoal = missionConfig.TurninGoal;
-                            var goldEnabled = turninGoal >= TurninState.Gold;
-                            var silverEnabled = turninGoal >= TurninState.Silver;
-                            var bronzeEnabled = turninGoal >= TurninState.Bronze;
+                            var timeExpired = turninGoal == TurninState.TimeExpired;
+                            var goldEnabled = !timeExpired && turninGoal >= TurninState.Gold;
+                            var silverEnabled = !timeExpired && turninGoal >= TurninState.Silver;
+                            var bronzeEnabled = !timeExpired && turninGoal >= TurninState.Bronze;
 
                             void DrawTurninButton(string id, TurninState state, bool enabled, Vector4 color, string tooltipLabel)
                             {
@@ -429,6 +430,16 @@ namespace ICE.Ui.MainUi.ModeSelect_Modes
                             DrawTurninButton("##Silver", TurninState.Silver, silverEnabled, SilverColor, "Silver");
                             ImGui.SameLine();
                             DrawTurninButton("##Bronze", TurninState.Bronze, bronzeEnabled, BronzeColor, "Bronze");
+                            ImGui.SameLine();
+                            ImGui.PushStyleColor(ImGuiCol.Text, timeExpired ? GoldColor : DisabledColor);
+                            if (ImGuiEx.IconButton(FontAwesomeIcon.Clock, "##TimeExpired", buttonSize))
+                            {
+                                missionConfig.TurninGoal = TurninState.TimeExpired;
+                                C.SaveDebounced();
+                            }
+                            ImGui.PopStyleColor();
+                            if (ImGui.IsItemHovered())
+                                ImGui.SetTooltip("Only turn in when the mission timer expires (keep gathering for max score).");
                         }
 
                         ImGui.TableNextColumn();

--- a/ICE/Utilities/Cosmic_Helper/CosmicSheets.cs
+++ b/ICE/Utilities/Cosmic_Helper/CosmicSheets.cs
@@ -141,6 +141,11 @@ public static unsafe partial class CosmicHelper
         public bool Drank => Rank == 1 && !Attributes.HasFlag(MissionAttributes.Critical);
         // Tool Mastery missions: Rank 6 like EX+, but not provisional/critical (EX+ are always weather/timed).
         public bool Master => Rank == 6 && !IsProvisional && !IsCritical;
+        // Work type by job (16=MIN, 17=BTN, 18=FSH), matching Task_ExecuteMission. Use these for routing/
+        // movement instead of the Gather/Fish attribute flags: some missions (e.g. Tool Mastery) carry no
+        // mapped WKSMissionText attribute yet still gather/fish, so the attribute flags miss them.
+        public bool IsGatherMission => Jobs.Contains(16) || Jobs.Contains(17);
+        public bool IsFishMission => Jobs.Contains(18);
         // Greater Reach missions are gathering missions whose base Gather flag was swapped for a
         // GreaterReach_* variant during parsing; treat them as gathering for routing/profile purposes.
         public bool IsGreaterReach => Attributes.HasFlag(MissionAttributes.GreaterReach_GatherX)

--- a/ICE/Utilities/ICEDictornaryCreation.cs
+++ b/ICE/Utilities/ICEDictornaryCreation.cs
@@ -155,7 +155,7 @@ public sealed partial class ICE
                     106 => MissionAttributes.Gather | MissionAttributes.Score_Chain,
                     107 => MissionAttributes.Gather | MissionAttributes.Score_Boon,
                     108 => MissionAttributes.Gather | MissionAttributes.Score_Chain | MissionAttributes.Score_Boon,
-                    109 or 111 => MissionAttributes.Gather | MissionAttributes.Collectables,
+                    109 or 111 or 372 => MissionAttributes.Gather | MissionAttributes.Collectables,
                     110 => MissionAttributes.Gather | MissionAttributes.ReducedItems | MissionAttributes.Score_TimeRemaining,
                     112 => MissionAttributes.Gather | MissionAttributes.ReducedItems,
                     113 => MissionAttributes.Fish | MissionAttributes.Score_Variety | MissionAttributes.Score_TimeRemaining,
@@ -171,6 +171,7 @@ public sealed partial class ICE
                     // Auxesia Tool Mastery gather missions (Geological/Botanical). They use Greater Reach,
                     // so the GreaterReach block below converts Chain+Boon into GreaterReach_Boon_Chain.
                     312 or 313 => MissionAttributes.Gather | MissionAttributes.Score_Chain | MissionAttributes.Score_Boon,
+
                     _ => MissionAttributes.None
                 };
             }


### PR DESCRIPTION
## Summary
Adds a **"Time Expired"** auto-turnin goal alongside the existing Gold/Silver/Bronze options, and fixes navigation for Tool Mastery (Master) gather/fish missions.

When selected, a mission **never turns in based on score** - it keeps gathering and only turns in when the **mission timer runs out** (via the existing `IsMissionTimedOut()` path).

## Why
Some missions - notably Auxesia **Tool Mastery** missions - extend their own timer each time you hit a goal. With a medal threshold the bot turns in as soon as it hits e.g. Gold, leaving score on the table. "Time Expired" lets it keep hitting goals (extending the timer and racking up score) until time finally expires, then turns in.

## Changes
- New `TurninState.TimeExpired`.
- A clock toggle (⏰) next to the Gold/Silver/Bronze trophy buttons in both the **mission table** and the **Expedition Log**; the trophies dim when it's selected, and a tooltip explains the behavior.
- No turn-in *decision* changes needed: `Gather_V2`/`Fish` already turn in on timeout, and the medal-threshold checks use exact `Gold/Silver/Bronze` matches, so `TimeExpired` simply never triggers an early turn-in.

## Fix: Master missions skipped aethernet / grabbed in place
On Tool Mastery (Master) MIN/BTN missions, the bot grabbed the mission instantly instead of moving to the node first, and when it did move it went **direct only, never via the aethernet**.

Root cause: `CheckForMovementRequired` was the only place classifying gather/fish missions by the **`Gather`/`Fish` attribute flags**, whereas execution (`Task_ExecuteMission`), the route loader, and `CosmicMoonContent` all classify by **job** (16/17 = MIN/BTN, 18 = FSH). Tool Mastery missions carry no mapped `WKSMissionText` attribute, so the movement check missed them: the mission was grabbed in place and the only movement left was the direct-only `Task_GatherMove`, never the aethernet-aware `Enqueue_NavmeshTask`.

Fix:
- Add job-based `IsGatherMission` / `IsFishMission` to `CosmicInfo` (mirroring `Task_ExecuteMission`).
- `CheckForMovementRequired` now uses those instead of the attribute flags, so movement and execution agree; the `[MoveCheck]` diagnostic log reports the same values.
